### PR TITLE
LRDOCS-8156-updates-to-building-content-pages-topic.

### DIFF
--- a/docs/dxp/7.x/en/site-building/creating-pages/building-and-managing-content-pages/building-content-pages.md
+++ b/docs/dxp/7.x/en/site-building/creating-pages/building-and-managing-content-pages/building-content-pages.md
@@ -1,5 +1,9 @@
 # Building Content Pages
 
+```note::
+   This information applies to Liferay DXP 7.3+. For previous Liferay DXP versions, see ![Liferay DXP 7.1 and 7.2](#liferay-dxp-7.1-and-7.2).
+```
+
 Once you've [added a Content Page](../adding-pages/adding-a-page-to-a-site.md), you may begin building your page by adding and configuring the various [Content Page elements](./content-pages-overview.md).
 
 When you enter the Site Builder view, you can add or edit your content using two different editing modes:
@@ -195,7 +199,7 @@ Compositions can be exported/imported between sites just as any other Fragment.
 1. Click the (![Cog icon](../../../images/icon-control-menu-gear.png)) to open the Section's Configuration Menu.
 1. Update the Section's *Container* setting to adjust the width styling (*Fixed Width* or *Fluid*), and update the *Padding Top* and *Padding Bottom* setting to adjust the padding for the Section container.
 
-![You can configure basic styling through the Section's Configuration Menu.](./building-content-pages/images/14.png)
+## Liferay DXP 7.1 and 7.2
 
 You can also configure a background image and color for a layout Section. See [Using a Background Image](#using-a-background-image) for more information.
 

--- a/docs/dxp/7.x/en/site-building/creating-pages/building-and-managing-content-pages/content-pages-overview.md
+++ b/docs/dxp/7.x/en/site-building/creating-pages/building-and-managing-content-pages/content-pages-overview.md
@@ -1,6 +1,8 @@
 # Content Pages Overview
 
-The default type of page used in Liferay DXP is a Content Page. The Content Page editing UI provides access to many different drag-and-drop elements (Fragments) that are available for immediate use with minimal configuration. Continue reading to get an overview of the Content Pages UI. See [Building Content Pages](./building-content-pages.md) to jump directly in to building a Content Page.
+```note::
+   This information applies to Liferay DXP 7.3+. For previous Liferay DXP versions, see ![Liferay DXP 7.1 and 7.2](#liferay-dxp-7.1-and-7.2).
+```
 
 ![Using the Content Page sidebar to add elements to the page.](./content-pages-overview/images/14.png)
 
@@ -90,9 +92,49 @@ The Widgets panel list the applications and tools available out-of-the-box that 
 
 ## Contents
 
-<!-- ```note::
-   Available in Liferay DXP 7.3+
-``` -->
+The *Contents* panel provides a list of the web content that's used on the page. This includes content displayed in a widget and content mapped to content fields. Click the *Contents* button (![Contents](../../../images/icon-contents.png)) to open the *Contents* panel. From this panel, you can perform a variety of actions to edit and manage web content. See [Managing Web Content on Content Pages](./managing-web-content-on-content-pages.md) for more information.
+
+## Page Structure
+
+*Page Structure* provides a hierarchical view of the Fragments and their contents on the page. Click on a field in the page structure to highlight it on the page. Headers and Footers appear in the hierarchy as well for custom [Master Page Templates](../defining-headers-and-footers/master-page-templates.md), but they're disabled because they can only be modified from the Master Page Template.
+
+![Page Structure shows you a hierarchy of your page and contents.](./content-pages-overview/images/08.png)
+
+## Page Design Options
+
+Click the *Look and Feel* icon (![Look and Feel](../../../images/icon-look-and-feel.png)) to change the theme or manage other options for the page. These options are further explored in [Configuring Individual Pages](../page-settings/configuring-individual-pages.md#look-and-feel).
+
+## Comments
+
+You can comment on a Page Fragment to discuss changes and collaborate. Comments are disabled by default, but Administrators can enable them. See [Using Fragment Comments](./using-fragment-comments.md) for more information.
+
+<!-- 
+####################################################
+Content from Liferay Help Center follows
+####################################################
+-->
+
+## Liferay DXP 7.1 and 7.2
+
+<!-- This content belongs to the "Content Page Management Interface" article in Liferay Help Center. -->
+
+Unlike Widget Pages, Content Pages can only be edited through the *Site 
+Builder* and cannot be edited live on the page. Any edits that you make to a 
+page are saved as a draft until you publish the page. Subsequent changes 
+after the initial publication are again saved as a draft, without affecting the 
+live page, until the page is published again. To create a Content Page,
+
+1.  Go to *Site Management* &rarr; *Site Builder* &rarr; *Pages*.
+
+2.  Click ![Add](../../../images/icon-add.png).
+
+3.  On the next page, select *Content Page* and provide a name for the page.
+
+    You will be brought to the Content Page management interface.
+ 
+    ![Figure 1: Each Content Page starts as a blank page.](./content-pages-overview/images/20.png)
+
+To edit an existing Content Page,
 
 > Available: Liferay DXP 7.3+
 


### PR DESCRIPTION
Changes:

1. Update the existing Learn content, including the newest 7.3 Content Page editor changes.
2. Copy the corresponding Liferay Docs markdown content at the bottom, after the "Liferay DXP 7.2 and Below" H2.
3. Minor update to the Liferay Docs content so it renders properly.
4. Replace relative links for absolute URLs in Liferay Docs content.
5. Copy all the necessary Liferay Docs images under the Liferay Learn images folder.
6. Include the following note at the beginning of the article: "This information applies to Liferay DXP 7.3+. For previous Liferay DXP versions, see [Liferay DXP 7.2 and Below]."
7. Maintain the final "Related Information" H2 at the very end (but this applies only to 7.3+ content.)
8. Remove the following notes (not longer necessary using the new layout): "Available: Liferay 7.3+; previously divided between *Sections* and *Section Builder* panels."

This was done for the following articles:

- Content Page Interface (Docs) → Content Pages Overview (Learn)
- Content Page Elements (Docs) → Building Content Pages (Learn)
- Using Widgets on Content Pages (Learn)

CC @jrhoun