### PR TITLE
LRDOCS-8816 Missing words in 'Content Page Management Interface' (learn update)

### DIFF
--- a/docs/dxp/7.x/en/site-building/creating-pages/building-and-managing-content-pages/content-pages-overview.md
+++ b/docs/dxp/7.x/en/site-building/creating-pages/building-and-managing-content-pages/content-pages-overview.md
@@ -4,11 +4,9 @@ By default, Liferay DXP uses the Content Page type, which provides a convenient 
 
 As with other page types, you can use [widgets](./using-widgets-on-a-content-page.md) to add dynamic functionality to a Content Page, integrating blogs, wikis, message boards, and more. Content Pages are primarily built using [Page Fragments](./using-fragments.md). Page Fragments are extensible, reusable page elements that include editable components, such as [text](./building-content-pages.md#editing-text-inline), [images](./building-content-pages.md#editing-images), and [links](./building-content-pages.md#editing-hyperlinks), which you can also [map](./building-content-pages.md#mapping-content) to available content. See [Using Fragments](./using-fragments.md) to learn more about DXP's out-of-the-box Fragments, or [Developing Fragments](../../developer-guide/developing-page-fragments/developing-fragments-intro.md) to learn how to create your own.
 
-![Build Content Pages using Fragments.](./content-pages-overview/images/01.png)
-
 When editing Content Pages, changes are made through a *Site Builder* and are saved as a draft. You can review, undo, and redo changes you've made during your current editing session, without affecting the live version. When ready, publish your changes immediately or enable a custom [Workflow](../../../process-automation/workflow/introduction-to-workflow.md) to direct the review and publishing process. You can also use Fragment and widget [comments](./using-fragment-comments.md) during this process to collaborate with team members.
 
-![When editing Content Pages, all changes are made to Content Pages  through a Site Builder.](./content-pages-overview/images/02.png)
+![When editing Content Pages, all changes are made to Content Pages  through a Site Builder.](./content-pages-overview/images/01.png)
 
 With Content Page Fragments and widgets, you can display web content, documents, and more. You can also view, edit, and manage your content, including content mapped to page fields. See [Managing Web Content on Content Pages](./managing-web-content-on-content-pages.md) for more information.
 

--- a/docs/dxp/7.x/en/site-building/creating-pages/building-and-managing-content-pages/editing-content-pages.md
+++ b/docs/dxp/7.x/en/site-building/creating-pages/building-and-managing-content-pages/editing-content-pages.md
@@ -144,7 +144,7 @@ The Widgets section functions just like the *Add* menu on a Widget Page. The ful
 
 ![The Widgets section provides a list of Widgets that can be added inside of a Layout.](./editing-content-pages/images/24.png)
 
-The main difference is that only the main configuration options for widgets on Content Pages. Various other configurations like *Look and Feel* are only available for widgets on Widget Pages.
+The main difference is that only the main configuration options are available for widgets on Content Pages. Various other configurations like *Look and Feel* are only available for widgets on Widget Pages.
 
 ### Page Structure
 


### PR DESCRIPTION
This PR proposes a change in the [7.2 section](https://github.com/sez11a/liferay-docs/pull/4931) of the [Content Pages Overview](https://learn.liferay.com/dxp/7.x/en/site-building/creating-pages/building-and-managing-content-pages/content-pages-overview.html) article in liferay-learn. This same change was proposed in liferay-docs in [PR 4931](https://github.com/sez11a/liferay-docs/pull/4931).

Proposed change (from [LRDOCS-8816](https://issues.liferay.com/browse/LRDOCS-8816))

- Fix wording.