### PR TITLE
[DXP Cloud] LRDOCS-9473 Remove link per request from marketing

### DIFF
--- a/docs/dxp-cloud/latest/en/manage-and-optimize/application-metrics.md
+++ b/docs/dxp-cloud/latest/en/manage-and-optimize/application-metrics.md
@@ -102,4 +102,3 @@ Log in with your Dynatrace credentials to check log trails and create custom das
 * [Introduction to the Liferay DXP Service](../using-the-liferay-dxp-service/introduction-to-the-liferay-dxp-service.md)
 * [Real-Time Alerts](./real-time-alerts.md)
 * [Quotas](./quotas.md)
-* [Advanced Monitoring: APM Tools - Dynatrace](https://help.liferay.com/hc/en-us/articles/360017896452-Advanced-Monitoring-APM-Tools-Dynatrace)


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-9473

The linked Help Center article references the interface users experience with a normal Dynatrace implementation, but this is not what users get when using Dynatrace with DXP Cloud. Thus it may be confusing to see this as a reference in this context. It was requested that this link be removed from the Application Metrics article for this reason.