### PR TITLE
[DXP Cloud] LRDOCS-9498 Typo fix

### DIFF
--- a/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/vpn-integration-overview.md
+++ b/docs/dxp-cloud/latest/en/infrastructure-and-operations/networking/vpn-integration-overview.md
@@ -22,7 +22,7 @@ The client to site VPN feature supports the following protocols:
 Subscribers can choose one of the protocols (IPSec or OpenVPN) to perform the connection from DXP Cloud console settings page for the desired environment. Any number of forwarding ports can be configured for the connection in the console UI.
 
 ```note::
-   Using the ``IKEv2`` protocol with an IPsec server, you can either use ``MSCHAPv2`` or ``TLS``authentication protocols. See `Basic Setup for an IPsec Server <./configuring-a-vpn-server.md#basic-setup-for-an-ipsec-server>`__ for more information.
+   Using the ``IKEv2`` protocol with an IPsec server, you can either use ``MSCHAPv2`` or ``TLS`` authentication protocols. See `Basic Setup for an IPsec Server <./configuring-a-vpn-server.md#basic-setup-for-an-ipsec-server>`__ for more information.
 ```
 
 See [Connecting a VPN Server to DXP Cloud](./connecting-a-vpn-server-to-dxp-cloud.md) for more information.


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-9498

Quick fix for a typo that slipped through the cracks in the VPN Integration Overview update. A whitespace is missing, and it broke the highlighting.