### PR TITLE
LRDOCS-9458 Minor fix for 'Content Performance' landing card

### DIFF
--- a/docs/dxp/latest/en/content-authoring-and-management/content_performance_panel.rst
+++ b/docs/dxp/latest/en/content-authoring-and-management/content_performance_panel.rst
@@ -1,5 +1,5 @@
-Content Performance Tool
-========================
+Content Performance Panel
+=========================
 
 .. toctree::
    :maxdepth: 3

--- a/docs/dxp/latest/en/content_authoring_and_management.rst
+++ b/docs/dxp/latest/en/content_authoring_and_management.rst
@@ -6,7 +6,7 @@ Content Authoring and Management
 
    content-authoring-and-management/asset_libraries.rst
    content-authoring-and-management/content_dashboard.rst
-   content-authoring-and-management/content_performance_tool.rst
+   content-authoring-and-management/content_performance_panel.rst
    content-authoring-and-management/web_content.rst
    content-authoring-and-management/documents_and_media.rst
    content-authoring-and-management/blogs.rst

--- a/docs/dxp/latest/en/landing.html
+++ b/docs/dxp/latest/en/landing.html
@@ -64,7 +64,7 @@
 							url: 'content-authoring-and-management/collections-and-collection-pages/about-collections-and-collection-pages.html'
 						},
 						{
-							name: 'About the Content Performance Tool',
+							name: 'About the Content Performance Panel',
 							url: 'content-authoring-and-management/content-performance-panel/about-the-content-performance-panel.html'
 						},
 					]


### PR DESCRIPTION
This PR fixes a minor problem with the card in the `landing.html` for the 'Content Authoring and Management' section.

This ticket is a follow-up to [LRDOCS-9458](https://issues.liferay.com/browse/LRDOCS-9458).