### PR TITLE
[DXP Cloud] LRDOCS-9508 Update Dynatrace token retrieval path

### DIFF
--- a/docs/dxp-cloud/latest/en/manage-and-optimize/application-metrics.md
+++ b/docs/dxp-cloud/latest/en/manage-and-optimize/application-metrics.md
@@ -77,7 +77,7 @@ Follow these steps to integrate Dynatrace:
 | Name | Description |
 | --- | --- |
 `LCP_PROJECT_MONITOR_DYNATRACE_TENANT` | A string of characters that is part of the URL (prefix) of your Dynatrace SaaS account. |
-`LCP_PROJECT_MONITOR_DYNATRACE_TOKEN` | A string of characters that you can find in your Dynatrace account at *Deploy Dynatrace* &rarr; *Start installation* &rarr; *Set up PaaS monitoring* &rarr; *Installer Download*. |
+`LCP_PROJECT_MONITOR_DYNATRACE_TOKEN` | A string of characters that you can find in your Dynatrace account. To get the token, navigate to *Manage* &rarr; *Deploy Dynatrace* &rarr; *Set up PaaS Integration*, then enter the environment ID and click *Generate new token*. |
 
 See the [official Dynatrace documentation](https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication/) for more information about these values.
 


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-9508

The Dynatrace website updated, and the path to generate a new token is now different. See the gif provided on the ticket for a demonstration of the new path (provided by Support).