### PR TITLE
search 7.x | elasticsearch connector config reference | LRDOCS-9431

### DIFF
--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch.rst
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch.rst
@@ -12,6 +12,7 @@ Elasticsearch
    elasticsearch/troubleshooting-elasticsearch-installation.md
    elasticsearch/using-the-sidecar-or-embedded-elasticsearch.md
    elasticsearch/upgrading_elasticsearch.rst
+   elasticsearch/elasticsearch-connector-settings.md
    
 Elasticsearch is the highly scalable, full-text search engine Liferay uses by default. Elasticsearch is bundled with Liferay for non-production purposes. In production, Liferay requires Elasticsearch running on a separate remote server.
 

--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
@@ -5,77 +5,78 @@ Elasticsearch is Liferay's default search engine. The connection to Elasticsearc
 <!-- If we like these tables, they'll require reorganization -->
 **Configuration Files and System Settings Entries:**
 
-| Server Versions | Configuration File Name | System Settings Entry |
-| --------------- | ----------------------- | --------------------- |
-| Liferay 7.2.x<br />Elasticsearch 6.x           | `com.liferay.portal.search.elasticsearch6.configuration.ElasticsearchConfiguration.config` | Elasticsearch 6 |
-| Liferay 7.2.x<br />Elasticsearch 7.x           | `com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config` | Elasticsearch 7
-| Liferay 7.3.x<br />Elasticsearch 7.x           | `com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config`<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConnectionConfiguration-[key].config` | Elasticsearch 7<br /><br /><br /><br /><br />Elasticsearch Connections (factory) |
+| Connecting Servers | <div style="width:380px">System Settings Entry/Configuration File</div> |
+| --------------- | -------------------------------------- | 
+| Liferay 7.2.x<br />Elasticsearch 6.x           | Elasticsearch 6<br />`com.liferay.portal.search.elasticsearch6.configuration.ElasticsearchConfiguration.config` |
+| Liferay 7.2.x<br />Elasticsearch 7.x           | Elasticsearch 7<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config` |
+| Liferay 7.3.x<br />Elasticsearch 7.x           | Elasticsearch 7<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config`<br /><br />Elasticsearch Connections (factory)<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConnectionConfiguration-[key].config` |
 
 **Configuration Properties Overview:**
 
-| **System Settings Configuration Label** | **Configuration File Field Name**<br />(default value) | **Liferay/Elasticsearch Version Details** |
-| ----------------------------------- | -------------------------------------------------- | --------------- | 
+| System Settings Field | <div style="width:280px">Configuration File Field**<br />(default value) | Liferay/Elasticsearch Version Details |
+| ----------------------------------- | -------------------------------------------------- | ------------------------------------- | 
+| | GENERAL CONNECTION SETTINGS |
+| Node Name | `nodeName=` | Liferay 7.3+ |
+| Track Total Hits | `trackTotalHits="true"` | Liferay 7.2+ |
+| Production Mode Enabled | `productionModeEnabled="false"` | Liferay 7.3+ |
+| Index Name Prefix | `indexNamePrefix=liferay-` | Liferay 7.2+ |
+| 7.3.x&rarr;Number of Company and System Index Replicas<br />7.2.x&rarr;Index Number of Replicas | `indexNumberOfReplicas=""` | Liferay 7.2+ |
+| 7.3.x&rarr;Number of Company and System Index Shards<br />7.2.x&rarr;Index Number of Shards | `indexNumberOfShards=""` | Liferay 7.2+ |
+| Log Exceptions Only | `logExceptionsOnly="true"` | Liferay 7.2+ |
+| Retry On Conflict | `retryOnConflict="5"` | Liferay 7.2+ |
 | | *SECURITY SETTINGS* |
-| Authentication Enabled | `authenticationEnabled` | Liferay 7.3+ |
-| Username | `username` | Liferay 7.3+ |
-| Password | `password` | Liferay 7.3+ |
-| Http SSL Enabled | `httpSSLEnabled` | Liferay 7.3+ |
-| Truststore Type | `truststoreType` | Liferay 7.3+ |
-| Truststore Path | `truststorePath` | Liferay 7.3+ |
-| Truststore Password | `truststorePassword` | |
+| Authentication Enabled | `authenticationEnabled="false"` | Liferay 7.3+ |
+| Username | `username="elastic"` | Liferay 7.3+ |
+| Password | `password=` | Liferay 7.3+ |
+| Http SSL Enabled | `httpSSLEnabled="false"` | Liferay 7.3+ |
+| Truststore Type | `truststoreType="pkcs12"` | Liferay 7.3+ |
+| Truststore Path | `truststorePath="/path/to/localhost.p12"` | Liferay 7.3+ |
+| Truststore Password | `truststorePassword=` | Liferay 7.3+ |
 | | *ELASTICSEARCH CONNECTIONS SETTINGS* |
 | Active | `active="false"` | Liferay 7.3+ |
 | Connection ID | `connectionId=` | Liferay 7.3+ |
 | | *CONNECTION DECLARATION SETTINGS* |
-| Remote Cluster Connection ID | `remoteClusterConnectionId` | Liferay 7.3+ if using the `ElasticsearchConnectionConfiguration` |
+| Remote Cluster Connection ID | `remoteClusterConnectionId=` | Liferay 7.3+ if using the `ElasticsearchConnectionConfiguration` |
 | | *REST CLIENT SETTINGS* |
 | Network Host Addresses | `networkHostAddresses=http://localhost:9200` | Liferay 7.3+ |
+| REST Client Logger Level | `RESTClientLoggerLevel="ERROR"` | Liferay 7.3+ |
 | | *TRANSPORT CLIENT SETTINGS* |
 | Cluster Name | `clusterName=LiferayElasticsearchCluster` | Liferay 7.2-<br />On 7.3+, applies only to development mode |
 | Transport Addresses | `transportAddresses=localhost:9300` | Liferay 7.2- |
-| Client Transport Sniff | `clientTransportSniff=true` | |
-| Client Transport Ignore Cluster Name | `clientTransportIgnoreClusterName=false` | |
-| Client Transport Ping Timeout | `clientTransportPingTimeout=` | |
-| Client Transport Nodes Sampler Interval | `clientTransportNodesSamplerInterval=` | |
+| Client Transport Sniff | `clientTransportSniff=true` | Liferay 7.2- |
+| Client Transport Ignore Cluster Name | `clientTransportIgnoreClusterName=false` | Liferay 7.2- |
+| Client Transport Ping Timeout | `clientTransportPingTimeout=` | Liferay 7.2- |
+| Client Transport Nodes Sampler Interval | `clientTransportNodesSamplerInterval=` | Liferay 7.2- |
 | | *DEVELOPMENT MODE SETTINGS* | 
 | Additional Configurations | `additionalConfigurations=` | Liferay 7.2+ |
-| Bootstrap Mlock All | `bootstrapMlockAll=false` | Liferay 7.2+ |
-| Http CORS Allow Origin | `httpCORSAllowOrigin=/https?:\\/\\/localhost(:[0-9]+)?/` | |
-| Http CORS Configurations | `httpCORSConfigurations=` | |
-| Http CORS Enabled | `httpCORSEnabled=true` | |
-| Network Host | `networkHost=` | Liferay 7.2+  |
-| Network Bind Host | `networkBindHost=` | Liferay 7.2+ |
-| Network Publish Host | `networkPublishHost=` | Liferay 7.2+ |
-| Sidecar Debug | `sidecarDebug` | Liferay 7.3+ |
-| Sidecar Debug Settings | `sidecarDebugSettings` | Liferay 7.3+ |
-| Sidecar Heartbeat Interval | `sidecarHeartbeatInterval` | Liferay 7.3+ |
-| Sidecar Home | `sidecarHome` | Liferay 7.3+ |
-| Sidecar HTTP Port | `sidecarHttpPort=9200` | Liferay 7.3+ |
-| Sidecar JVM Options | `sidecarJVMOptions` | Liferay 7.3+ |
-| Sidecar Shutdown Timeout | `sidecarShutdownTimeout` | Liferay 7.3+ |
-| Transport Tcp Port | `transportTcpPort=` | Liferay 7.2+ |
-| Zen Discovery Unicast Hosts Port | `discoveryZenPingUnicastHostsPort=9300-9400` | Liferay 7.2+ |
-| | GENERAL CONNECTION SETTINGS |
-| Node Name | `nodeName` | Liferay 7.3+ |
-| Track Total Hits | `trackTotalHits` | Liferay 7.2+ |
-| Production Mode Enabled | `productionModeEnabled="false"` | Liferay 7.3+ |
-| Index Name Prefix | `indexNamePrefix=liferay-` | Liferay 7.2+ |
-| 7.3.x&rarr;Number of Company and System Index Replicas<br />7.2.x&rarr;Index Number of Replicas | `indexNumberOfReplicas=` | Liferay 7.2+ |
-| 7.3.x&rarr;Number of Company and System Index Shards<br />7.2.x&rarr;Index Number of Shards | `indexNumberOfShards=` | Liferay 7.2+ |
-| Log Exceptions Only | `logExceptionsOnly=true` | Liferay 7.2+ |
-| Retry On Conflict | `retryOnConflict=5` | Liferay 7.2+ |
+| Bootstrap Mlock All | `bootstrapMlockAll="false"` | Liferay 7.2+ |
+| Http CORS Allow Origin | `httpCORSAllowOrigin="/https?:\\/\\/localhost(:[0-9]+)?/"` | Liferay 7.2+ |
+| Http CORS Configurations | `httpCORSConfigurations=` | Liferay 7.2+ |
+| Http CORS Enabled | `httpCORSEnabled="true"` | Liferay 7.2+ |
+| Network Host | `networkHost=""` | Liferay 7.2+  |
+| Network Bind Host | `networkBindHost=""` | Liferay 7.2+ |
+| Network Publish Host | `networkPublishHost=""` | Liferay 7.2+ |
+| Sidecar Debug | `sidecarDebug="false"` | Liferay 7.3+ |
+| Sidecar Debug Settings | `sidecarDebugSettings="-agentlib:jdwp=transport=dt_socket,address=8001,server=y,suspend=y,quiet=y"` | Liferay 7.3+ |
+| Sidecar Heartbeat Interval | `sidecarHeartbeatInterval="10000"` | Liferay 7.3+ |
+| Sidecar Home | `sidecarHome="elasticsearch7"` | Liferay 7.3+ |
+| Sidecar HTTP Port | `sidecarHttpPort="9200"` | Liferay 7.3+ |
+| Sidecar JVM Options | `sidecarJVMOptions="-Xms1g|-Xmx1g|-XX:+AlwaysPreTouch"` | Liferay 7.3+ |
+| Sidecar Shutdown Timeout | `sidecarShutdownTimeout="10000"` | Liferay 7.3+ |
+| Transport Tcp Port | `transportTcpPort=""` | Liferay 7.2+ |
+| Zen Discovery Unicast Hosts Port | `discoveryZenPingUnicastHostsPort="9300-9400"` | Liferay 7.2+ |
 | | ADVANCED CONFIGURATION |
 | Additional Index Configurations | `additionalIndexConfigurations=` | Liferay 7.2+ |
 | Additional Type Mappings | `additionalTypeMappings=` | Liferay 7.2+ |
 | Override Type Mappings | `overrideTypeMappings=` | Liferay 7.2+ |
-| Proxy Host | `proxyHost` | Liferay 7.3+ |
-| Proxy Port | `proxyPort=0` | Liferay 7.3+ |
-| Proxy Username | `proxyUserName` | Liferay 7.3+ |
-| Proxy Password | `proxyPassword` | Liferay 7.3+ |
+| Proxy Host | `proxyHost=` | Liferay 7.3+ |
+| Proxy Port | `proxyPort="0"` | Liferay 7.3+ |
+| Proxy Username | `proxyUserName=` | Liferay 7.3+ |
+| Proxy Password | `proxyPassword=` | Liferay 7.3+ |
 | | *DEPRECATED* |
 | Operation Mode | `operationMode="EMBEDDED"` | Deprecated in Liferay 7.3.x |
-| Embedded HTTP Port | `embeddedHttpPort=9201` | Deprecated in Liferay 7.3.x |
-| Http Enabled | `httpEnabled=true` | Deprecated in Liferay 7.1.x<br />Deprecated Elasticsearch 6.3.x |
+| Embedded HTTP Port | `embeddedHttpPort="9201"` | Deprecated in Liferay 7.3.x |
+| Http Enabled | `httpEnabled="true"` | Deprecated in Liferay 7.1.x<br />Deprecated Elasticsearch 6.3.x |
 
 ## Elasticsearch Connection Configuration Files
 

--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
@@ -1,20 +1,8 @@
-# Elasticsearch Connector Reference
+# Elasticsearch Connector Configuration Reference
 
-> The configuration information here applies to the latest available (bundled or through Marketplace) version of the Elasticsearch 6 and Elasticsearch 7 connectors for Liferay Portal 7.3 CE and for Liferay DXP 7.2 and 7.3. Appropriate information about the exact GA/Service Pack/Fix Pack and Marketplace versions are provided where needed.
+> The configuration information here applies to the latest available (bundled or through Marketplace) version of the Elasticsearch 6 and Elasticsearch 7 connectors for Liferay Portal 7.3 & 7.4 CE and for Liferay DXP 7.2 & 7.3. Appropriate information about the exact GA/Service Pack/Fix Pack and Marketplace versions are provided where needed.
 
-## Introduction
-Elasticsearch is Liferay's default search engine. Each Liferay Portal CE and Liferay DXP version is **bundled** with a connector to Elasticsearch that is compatible with a specific Elasticsearch major version:
-
-    Liferay DXP 7.2 & Liferay Portal 7.2 CE => Elasticsearch 6
-    Liferay DXP 7.3 & Liferay Portal 7.3 CE => Elasticsearch 7
-    
-To add support for newer major Elasticsearch versions for released DXP versions, Liferay releases **new connectors through Marketplace**. These connectors can be used as drop-in replacements for the out-of-the-box (bundled) connectors:
-
-    Liferay DXP 7.2 => Liferay Connector to Elasticsearch 7
-
-Most of the time, the last released connector on Marketplace for one DXP version becomes the out-of-the-box bundled connector in the next DXP version. For example, DXP 7.3 comes with the Liferay Connector to Elasticsearch 7 bundled, and this connector is available for Liferay 7.2 on Marketplace.
-
-## Configuration Overview
+## Overview
 
 The connection to Elasticsearch is primarily defined in the _Elasticsearch 6/7_ configuration entry in System Settings (or via [corresponding configuration file](#elasticsearch-connection-configuration-entries)). Liferay 7.3 introduced the possibility to define multiple connections to Elasticsearch, through the [factory configuration](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-factory-configuration.md) _Elasticsearch Connections_ configuration. Both configuration entries are configurable through [System Settings](../../../system-administration/configuring-liferay/system-settings.md) or an [OSGi configuration file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md) (recommended: use config files). 
 
@@ -279,3 +267,5 @@ Set the password for connecting to the proxy.
 - [What's New in Search for 7.3?](../../getting-started/whats-new-in-search-for-73.md)
 - [Securing Elasticsearch](securing-elasticsearch.md)
 - [Connecting to Elasticsearch](connecting-to-elasticsearch.md)
+- [Liferay DXP Elasticsearch Connectors: Technical Data Sheet (KB Reference)](https://help.liferay.com/hc/en-us/articles/360046478452)
+- [Understanding Liferay DXP's compatibility with Elasticsearch (KB Reference)](https://help.liferay.com/hc/en-us/articles/360051492032)

--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
@@ -10,7 +10,7 @@ The connection to Elasticsearch is primarily defined in the _Elasticsearch 6/7_ 
 | --------------- | -------------------------------------- | 
 | Liferay 7.2.x<br />Elasticsearch 6.x  | Elasticsearch 6<br />`com.liferay.portal.search.elasticsearch6.configuration.ElasticsearchConfiguration.config` |
 | Liferay 7.2.x<br />Elasticsearch 7.x  | Elasticsearch 7<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config` |
-| Liferay 7.3.x<br />Elasticsearch 7.x  | Elasticsearch 7<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config`<br /><br />Elasticsearch Connections (factory)<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConnectionConfiguration-[key].config` |
+| Liferay 7.3.x<br />Elasticsearch 7.x  | Elasticsearch 7<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config`<br /><br />Elasticsearch Connections (factory)<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConnectionConfiguration-[connectionId].config` |
 
 In Liferay 7.3 and beyond, there's an additional connection configuration entry, Elasticsearch Connections. You can use this to define any connection to Elasticsearch, but if you are only configuring one connection you can still use the main Elasticsearch 7 configuration entry. If using multiple connections in 7.3+, define connections with files named accordingly:
 

--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
@@ -1,3 +1,118 @@
-# Elasticsearch Connector Settings
+# Elasticsearch Connection Settings
 
-Coming soon!
+Elasticsearch is Liferay's default search engine. The connection is managed through the *Liferay Connector to Elasticsearch [Version]*, and is configurable through [System Settings](../../../system-administration/configuring-liferay/system-settings.md) or an [OSGi configuration file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md) named
+
+```
+com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config
+```
+
+If using Elasticsearch 6 on Liferay 7.2, the configuration file is named
+
+```
+com.liferay.portal.search.elasticsearch6.configuration.ElasticsearchConfiguration.config
+```
+
+Deploy the file to `[Liferay_Home]/osgi/configs` and a listener auto-detects it.
+
+The list below is all the configuration settings for Liferay's default Elasticsearch connector, in the order they appear in the System Settings application (The _Elasticsearch [Version]_ entry under the _Search_ category):
+
+**Cluster Name, `clusterName=LiferayElasticsearchCluster`**
+A String value that sets the name of the cluster to integrate with. This name should match the remote cluster when Operation Mode is set to remote.  (See also: remote operation mode)
+
+**Operation Mode, `operationMode=EMBEDDED`**
+There are two operation modes you can choose from: EMBEDDED or REMOTE. Set to REMOTE to connect to a remote standalone Elasticsearch cluster. Set to EMBEDDED to start Liferay with an internal Elasticsearch instance. Embedded operation mode is unsupported for production environments.
+
+**Index Name Prefix, `indexNamePrefix=liferay-`**
+Set a String value to use as the prefix for the search index name. The default value should not be changed under normal conditions. If you change it, you must also perform a *reindex all* operation for the portal and then manually delete the old index using the Elasticsearch administration console.
+
+**Index Number of Replicas, `indexNumberOfReplicas=`**
+t the number of replicas for each index. If left unset, no replicas are used.  A full reindex is required to make changes take effect.
+
+**Index Number of Shards, `indexNumberOfShards=`**
+t the number of index shards to use when a Liferay index is created. If left unset, a single shard is used. A full reindex is required to make changes take effect. 
+
+**Bootstrap Mlock All, `bootstrapMlockAll=false`**
+A boolean setting that, when set to `true`, tries to lock the process address space into RAM, preventing any Elasticsearch memory from being swapped out (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/setup-configuration-memory.html#bootstrap-memory_lock)) for more information)
+
+**Log Exceptions Only, `logExceptionsOnly=true`**
+A boolean setting that, when set to true, only logs exceptions from Elasticsearch, and does not rethrow them.
+
+**Retry On Conflict, `retryOnConflict=5`**
+Set an int value for the number of retries to attempt if a version conflict occurs because the document was updated between getting it and updating it (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/docs-update.html#docs-update-api-query-params) for more information).
+
+**Discovery Zen Ping Unicast Hosts Port, `discoveryZenPingUnicastHostsPort=9300-9400`**
+Set a String value for the range of ports to use when building the value for discovery.zen.ping.unicast.hosts. Multiple Elasticsearch nodes on a range of ports can act as gossip routers at the same computer (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-discovery-hosts-providers.html) for more information).
+
+**Network Host, `networkHost=`**
+Set this String value to instruct the node to bind to this hostname or IP address and publish (advertise) this host to other nodes in the cluster. This is a shortcut which sets the bind host and the publish host at the same time (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#common-network-settings) for more information).
+
+**Network Bind Host, `networkBindHost=`**
+Set the String value of the network interface(s) a node should bind to in order to listen for incoming requests (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#advanced-network-settings) for more information).
+
+**Network Publish Host, `networkPublishHost=`**
+Set the String value of a single interface that the node advertises to other nodes in the cluster, so that those nodes can connect to it (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#advanced-network-settings) for more information).
+
+**Transport Tcp Port, `transportTcpPort=`**
+Set the String value for the port to bind for communication between nodes.  Accepts a single value or a range (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-transport.html#_tcp_transport) for more information).
+
+**Transport Addresses, `transportAddresses=localhost:9300`**
+Set the String values for the addresses of the remote Elasticsearch nodes to connect to. This value is required when Operation Mode is set to remote (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information). Specify as many or few nodes as you see fit.
+
+**Client Transport Sniff, `clientTransportSniff=true`**
+Set this boolean to true to enable cluster sniffing and dynamically discover available data nodes in the cluster (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).
+
+**Client Transport Ignore Cluster Name, `clientTransportIgnoreClusterName=false`**
+Set this boolean to true to ignore cluster name validation of connected nodes (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).
+
+**Client Transport Ping Timeout, `clientTransportPingTimeout=`**
+e time (in seconds) the client node waits for a ping response from a node. If unset, the default Elasticsearch `client.transport.ping_timeout` is used.
+
+**Client Transport Nodes Sampler Interval, `clientTransportNodesSamplerInterval=`**
+Set this String value to instruct the client node on how often to sample / ping the nodes listed and connected (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).
+
+**Http Enabled, `httpEnabled=true`**
+Set this boolean to false to disable the http layer entirely on nodes which are not meant to serve REST requests directly. As this setting was [deprecated in Elasticsearch 6.3](https://www.elastic.co/guide/en/elasticsearch/reference/6.7/release-notes-6.3.0.html#deprecation-6.3.0), the connector's corresponding setting is now also deprecated. This setting was only used for configuring the embedded Elasticsearch server, so its deprecation should have minimal impact to production deployments.
+
+**Http CORS Enabled, `httpCORSEnabled=true`**
+Set this boolean to false to disable cross-origin resource sharing, i.e. whether a browser on another origin can do requests to Elasticsearch. If disabled, web front end tools like elasticsearch-head may be unable to connect (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).
+
+**Http CORS Allow Origin, `httpCORSAllowOrigin=/https?:\\/\\/localhost(:[0-9]+)?/`**
+Set the String origins to allow when HTTP CORS is enabled (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).
+
+**Http CORS Configurations, `httpCORSConfigurations=`**
+Set the String values for custom settings for HTTP CORS, in YML format (`elasticsearch.yml`) (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).
+
+**Additional Configurations, `additionalConfigurations=`**
+Set the String values for custom settings for embedded Elasticsearch, in YML format. See: Adding Settings to the Liferay Elasticsearch Connector
+
+**Additional Index Configurations, `additionalIndexConfigurations=`**
+Set the String values for custom settings for the Liferay index, in JSON or YML format (refer to the Elasticsearch Create Index API for more information).  See: Adding Settings to the Liferay Elasticsearch Connector
+
+**Additional Type Mappings, `additionalTypeMappings=`**
+Set the String values for custom mappings for the `LiferayDocumentType`, in JSON format (refer to the Elasticsearch Put Mapping API for more information) See: Adding Settings to the Liferay Elasticsearch Connector
+
+**Override Type Mappings, `overrideTypeMappings=`**
+ttings here override @product@'s default type mappings. This is an advanced feature that should be used only if strictly necessary. If you set this value, the default mappings used to define the Liferay Document Type in @product@ source code (for example, `liferay-type-mappings.json`) are ignored entirely, so include the whole mappings definition in this property, not just the segment you're modifying.
+
+## Configurations only Affecting the Embedded Elasticsearch Server
+
+These settings (defined above) are only meant to use while configuring the [embedded Elasticsearch server]((using-the-sidecar-or-embedded-elasticsearch.md)). Configuring these will elicit no effect on remote Elasticsearch installations:
+
+- `bootstrapMlockAll`
+- `discoveryZenPingUnicastHostsPort`
+- `networkHost`
+- `networkBindHost`
+- `networkPublishHost` 
+- `transportTcpPort` 
+- `httpEnabled`
+- `httpCORSEnabled` 
+- `httpCORSAllowOrigin` 
+- `httpCORSConfigurations` 
+
+You can configure these settings in the System Setting application, or as mentioned above, you can specify them in a deployable OSGi `.config` file.
+
+## Related Topics
+
+- [What's New in Search for 7.3?](../../getting-started/whats-new-in-search-for-73.md)
+- [Securing Elasticsearch](securing-elasticsearch.md)
+- [Connecting to Elasticsearch](connecting-to-elasticsearch.md)

--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
@@ -1,29 +1,23 @@
 # Elasticsearch Connection Settings
 
-Elasticsearch is Liferay's default search engine. The connection to Elasticsearch is primarily defined in the Elasticsearch 6/7 configuration entry in System Settings (or via corresponding configuration file). Liferay 7.3 introduced the possibility to define multiple connections to Elasticsearch, through the [factory configuration](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-factory-configuration.md) Elasticsearch Connections configuration. Both configuration entries are configurable through [System Settings](../../../system-administration/configuring-liferay/system-settings.md) or an [OSGi configuration file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md). 
+> The configuration information here applies to Liferay's Elasticsearch connector as of Liferay DXP 7.3.10 SP1. Information for Liferay 7.2 is provided where appropriate.
 
-<!-- If we like these tables, they'll require reorganization -->
-**Configuration Files and System Settings Entries:**
+Elasticsearch is Liferay's default search engine. The connection to Elasticsearch is primarily defined in the _Elasticsearch 7_ configuration entry in System Settings (or via [corresponding configuration file](#elasticsearch-connection-configuration-entries)). Liferay 7.3 introduced the possibility to define multiple connections to Elasticsearch, through the [factory configuration](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-factory-configuration.md) _Elasticsearch Connections_ configuration. Both configuration entries are configurable through [System Settings](../../../system-administration/configuring-liferay/system-settings.md) or an [OSGi configuration file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md). 
 
-| Connecting Servers | <div style="width:380px">System Settings Entry/Configuration File</div> |
-| --------------- | -------------------------------------- | 
-| Liferay 7.2.x<br />Elasticsearch 6.x           | Elasticsearch 6<br />`com.liferay.portal.search.elasticsearch6.configuration.ElasticsearchConfiguration.config` |
-| Liferay 7.2.x<br />Elasticsearch 7.x           | Elasticsearch 7<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config` |
-| Liferay 7.3.x<br />Elasticsearch 7.x           | Elasticsearch 7<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config`<br /><br />Elasticsearch Connections (factory)<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConnectionConfiguration-[key].config` |
+[**Click here to jump to the property descriptions.**](#property-descriptions)
 
 **Configuration Properties Overview:**
 
 | System Settings Field | <div style="width:280px">Configuration File Field**<br />(default value) | Liferay/Elasticsearch Version Details |
 | ----------------------------------- | -------------------------------------------------- | ------------------------------------- | 
 | | GENERAL CONNECTION SETTINGS |
-| Node Name | `nodeName=` | Liferay 7.3+ |
-| Track Total Hits | `trackTotalHits="true"` | Liferay 7.2+ |
+| Track Total Hits | `trackTotalHits="true"` | Liferay 7.2+<br />Elasticsearch 7 |
 | Production Mode Enabled | `productionModeEnabled="false"` | Liferay 7.3+ |
-| Index Name Prefix | `indexNamePrefix=liferay-` | Liferay 7.2+ |
+| Index Name Prefix | `indexNamePrefix="liferay-"` | Liferay 7.2+ |
 | 7.3.x&rarr;Number of Company and System Index Replicas<br />7.2.x&rarr;Index Number of Replicas | `indexNumberOfReplicas=""` | Liferay 7.2+ |
 | 7.3.x&rarr;Number of Company and System Index Shards<br />7.2.x&rarr;Index Number of Shards | `indexNumberOfShards=""` | Liferay 7.2+ |
 | Log Exceptions Only | `logExceptionsOnly="true"` | Liferay 7.2+ |
-| Retry On Conflict | `retryOnConflict="5"` | Liferay 7.2+ |
+| Retry On Conflict | `retryOnConflict="5"` | Liferay 7.2- |
 | | *SECURITY SETTINGS* |
 | Authentication Enabled | `authenticationEnabled="false"` | Liferay 7.3+ |
 | Username | `username="elastic"` | Liferay 7.3+ |
@@ -38,13 +32,13 @@ Elasticsearch is Liferay's default search engine. The connection to Elasticsearc
 | | *CONNECTION DECLARATION SETTINGS* |
 | Remote Cluster Connection ID | `remoteClusterConnectionId=` | Liferay 7.3+ if using the `ElasticsearchConnectionConfiguration` |
 | | *REST CLIENT SETTINGS* |
-| Network Host Addresses | `networkHostAddresses=http://localhost:9200` | Liferay 7.3+ |
+| Network Host Addresses | `networkHostAddresses="http://localhost:9200"` | Liferay 7.3+ |
 | REST Client Logger Level | `RESTClientLoggerLevel="ERROR"` | Liferay 7.3+ |
 | | *TRANSPORT CLIENT SETTINGS* |
-| Cluster Name | `clusterName=LiferayElasticsearchCluster` | Liferay 7.2-<br />On 7.3+, applies only to development mode |
-| Transport Addresses | `transportAddresses=localhost:9300` | Liferay 7.2- |
-| Client Transport Sniff | `clientTransportSniff=true` | Liferay 7.2- |
-| Client Transport Ignore Cluster Name | `clientTransportIgnoreClusterName=false` | Liferay 7.2- |
+| Cluster Name | `clusterName="LiferayElasticsearchCluster"` | Liferay 7.2-<br />On 7.3+, applies to development mode |
+| Transport Addresses | `transportAddresses="localhost:9300"` | Liferay 7.2- |
+| Client Transport Sniff | `clientTransportSniff="true"` | Liferay 7.2- |
+| Client Transport Ignore Cluster Name | `clientTransportIgnoreClusterName="false"` | Liferay 7.2- |
 | Client Transport Ping Timeout | `clientTransportPingTimeout=` | Liferay 7.2- |
 | Client Transport Nodes Sampler Interval | `clientTransportNodesSamplerInterval=` | Liferay 7.2- |
 | | *DEVELOPMENT MODE SETTINGS* | 
@@ -56,6 +50,7 @@ Elasticsearch is Liferay's default search engine. The connection to Elasticsearc
 | Network Host | `networkHost=""` | Liferay 7.2+  |
 | Network Bind Host | `networkBindHost=""` | Liferay 7.2+ |
 | Network Publish Host | `networkPublishHost=""` | Liferay 7.2+ |
+| Node Name | `nodeName=` | Liferay 7.3+ |
 | Sidecar Debug | `sidecarDebug="false"` | Liferay 7.3+ |
 | Sidecar Debug Settings | `sidecarDebugSettings="-agentlib:jdwp=transport=dt_socket,address=8001,server=y,suspend=y,quiet=y"` | Liferay 7.3+ |
 | Sidecar Heartbeat Interval | `sidecarHeartbeatInterval="10000"` | Liferay 7.3+ |
@@ -78,15 +73,17 @@ Elasticsearch is Liferay's default search engine. The connection to Elasticsearc
 | Embedded HTTP Port | `embeddedHttpPort="9201"` | Deprecated in Liferay 7.3.x |
 | Http Enabled | `httpEnabled="true"` | Deprecated in Liferay 7.1.x<br />Deprecated Elasticsearch 6.3.x |
 
-## Elasticsearch Connection Configuration Files
+## Elasticsearch Connection Configuration Entries
 
 In Liferay 7.3 and beyond (or on earlier versions with [LES Cross-Cluster Replication](../../liferay-enterprise-search/cross-cluster-replication/cross-cluster-replication.md)), there's an additional connection configuration entry, Elasticsearch Connections. You can use this to define any connection to Elasticsearch, but if you are only configuring one connection you can still use the Elasticsearch 7 configuration entry.
 
-If managing only one connection for Elasticsearch 7 the configuration file is
+**Configuration Files and System Settings Entries:**
 
-```
-com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config
-```
+| Connecting Servers | <div style="width:380px">System Settings Entry/Configuration File</div> |
+| --------------- | -------------------------------------- | 
+| Liferay 7.2.x<br />Elasticsearch 6.x  | Elasticsearch 6<br />`com.liferay.portal.search.elasticsearch6.configuration.ElasticsearchConfiguration.config` |
+| Liferay 7.2.x<br />Elasticsearch 7.x  | Elasticsearch 7<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config` |
+| Liferay 7.3.x<br />Elasticsearch 7.x  | Elasticsearch 7<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config`<br /><br />Elasticsearch Connections (factory)<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConnectionConfiguration-[key].config` |
 
 If using multiple connections, define connections with files named accordingly:
 
@@ -94,107 +91,37 @@ If using multiple connections, define connections with files named accordingly:
 com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConnectionConfiguration-[key].config
 ```
 
-If using Elasticsearch 6 on Liferay 7.2, the configuration file is named
-
-```
-com.liferay.portal.search.elasticsearch6.configuration.ElasticsearchConfiguration.config
-```
-
 If configuring security on Elasticsearch 6, a separate Liferay configuration (as well as a LES subscription) is required. See [Securing Elasticsearch](securing-elasticsearch.md) for more information.
 
-Deploy the files to `[Liferay_Home]/osgi/configs` and a listener auto-detects the configurations and writes them to the database.
+Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-detects the configurations and writes them to the database.
 
-## Elasticsearch Connection Settings
+## Property Descriptions
 
-The configuration settings listed are for Liferay's Elasticsearch connector as of Liferay DXP 7.3.10 SP1. Most of these settings can be defined in either the Elasticsearch 7 entry or Elasticsearch Connections, under the System Settings &rarr; Search category.
+The configuration settings are categorized by where they appear: those unique to the Elasticsearch 7 entry, those unique to the Elasticsearch connections entry, and those common to both. The Elasticsearch 7 and Elasticsearch Connections entries are found under System Settings &rarr; Search.
 
 ### Properties Unique to the Elasticsearch 7 Configuration
+
+Many of the connection settings are only found in the Elasticsearch 7 configuration entry. They can be categorized according to 
+
+- production mode settings for defining the connection mode and declaring which connection to use (if you have multiple connections defined in an Elasticsearch Connections entry)
+- development mode settings to configure the embedded or sidecar Elasticsearch (e.g., naming the server node)
+- Settings that are not specific to the connection, but that configure Liferay's search infrastructure or behavior (e.g., index name prefixes)
+
+#### Defining the Remote Connection
 
 **Production Mode Enabled, `productionModeEnabled="false"`** \
 Enable production mode. In Liferay 7.3, `productionModeEnabled` replaces the deprecated setting `operationMode`. If this is checked, production mode is enabled and the Operation Mode configuration is ignored. Enabling production mode requires connecting to a remote standalone Elasticsearch cluster. If left disabled, the Operation Mode configuration is used.
 
-[Deprecated] **Operation Mode, `operationMode="EMBEDDED"`** \
-There are two operation modes you can choose from: EMBEDDED or REMOTE. Set to REMOTE to connect to a remote standalone Elasticsearch cluster. Set to EMBEDDED to start Liferay with an internal Elasticsearch instance. EMBEDDED operation mode is unsupported for production environments.
+**Operation Mode, `operationMode="EMBEDDED"`** \
+There are two operation modes you can choose from: EMBEDDED or REMOTE. Set to REMOTE to connect to a remote standalone Elasticsearch cluster. Set to EMBEDDED to start Liferay with an internal Elasticsearch instance. EMBEDDED operation mode is unsupported for production environments and can be considered a "development mode" feature.
 
 **Remote Cluster Connection ID, `remoteClusterConnectionId`** \
 Choose the connection ID for a connection to the remote Elasticsearch cluster. The available connections are defined in the Elasticsearch Connections System Settings entry. If this value is not set then the connection configurations in the Elasticsearch 7 entry are used for the remote cluster connection.
 
-<!-- embedded only on 7.3 -->
-**Cluster Name, `clusterName=LiferayElasticsearchCluster`** \
-A String value that sets the name of the cluster to integrate with. This name should match the remote cluster when Operation Mode is set to remote.  (See also: remote operation mode)
+#### Configuring Liferay's Search Infrastructure
 
-
-### Properties Unique to the Elasticsearch Connections Configuration
-
-**Active, `active="false"`** \
-
-**Connection ID, `connectionId=`** \
-Set a unique ID for the connection. This is referenced in the Elasticsearch 7 property Remote Cluster Connection ID.
-
-### Properties Shared Between the Elasticsearch 7 and Elasticsearch Connections Configurations
-
-**Index Name Prefix, `indexNamePrefix=liferay-`** \
-Set a String value to use as the prefix for the search index name. The default value should not be changed under normal conditions. If you change it, you must also perform a *reindex all* operation for the portal and then manually delete the old index using the Elasticsearch administration console.
-
-**Index Number of Replicas, `indexNumberOfReplicas=`** \
-Set the number of replicas for each index. If left unset, no replicas are used.  A full reindex is required to make changes take effect.
-
-**Index Number of Shards, `indexNumberOfShards=`** \
-Set the number of index shards to use when a Liferay index is created. If left unset, a single shard is used. A full reindex is required to make changes take effect. 
-
-**Bootstrap Mlock All, `bootstrapMlockAll=false`** \
-A boolean setting that, when set to `true`, tries to lock the process address space into RAM, preventing any Elasticsearch memory from being swapped out (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/setup-configuration-memory.html#bootstrap-memory_lock)) for more information)
-
-**Log Exceptions Only, `logExceptionsOnly=true`** \
-A boolean setting that, when set to true, only logs exceptions from Elasticsearch, and does not rethrow them.
-
-**Retry On Conflict, `retryOnConflict=5`** \
-Set an int value for the number of retries to attempt if a version conflict occurs because the document was updated between getting it and updating it (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/docs-update.html#docs-update-api-query-params) for more information).
-
-**Discovery Zen Ping Unicast Hosts Port, `discoveryZenPingUnicastHostsPort=9300-9400`** \
-Set a String value for the range of ports to use when building the value for discovery.zen.ping.unicast.hosts. Multiple Elasticsearch nodes on a range of ports can act as gossip routers at the same computer (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-discovery-hosts-providers.html) for more information).
-
-**Network Host, `networkHost=`** \
-Set this String value to instruct the node to bind to this hostname or IP address and publish (advertise) this host to other nodes in the cluster. This is a shortcut which sets the bind host and the publish host at the same time (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#common-network-settings) for more information).
-
-**Network Bind Host, `networkBindHost=`** \
-Set the String value of the network interface(s) a node should bind to in order to listen for incoming requests (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#advanced-network-settings) for more information).
-
-**Network Publish Host, `networkPublishHost=`** \
-Set the String value of a single interface that the node advertises to other nodes in the cluster, so that those nodes can connect to it (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#advanced-network-settings) for more information).
-
-**Transport Tcp Port, `transportTcpPort=`** \
-Set the String value for the port to bind for communication between nodes.  Accepts a single value or a range (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-transport.html#_tcp_transport) for more information).
-
-**Transport Addresses, `transportAddresses=localhost:9300`** \
-Set the String values for the addresses of the remote Elasticsearch nodes to connect to. This value is required when Operation Mode is set to remote (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information). Specify as many or few nodes as you see fit.
-
-**Client Transport Sniff, `clientTransportSniff=true`** \
-Set this boolean to true to enable cluster sniffing and dynamically discover available data nodes in the cluster (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).
-
-**Client Transport Ignore Cluster Name, `clientTransportIgnoreClusterName=false`** \
-Set this boolean to true to ignore cluster name validation of connected nodes (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).
-
-**Client Transport Ping Timeout, `clientTransportPingTimeout=`** \
-Set the time (in seconds) the client node waits for a ping response from a node. If unset, the default Elasticsearch `client.transport.ping_timeout` is used.
-
-**Client Transport Nodes Sampler Interval, `clientTransportNodesSamplerInterval=`** \
-Set this String value to instruct the client node on how often to sample / ping the nodes listed and connected (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).
-
-**Http Enabled, `httpEnabled=true`** \
-Set this boolean to false to disable the HTTP layer entirely on nodes which are not meant to serve REST requests directly. As this setting was [deprecated in Elasticsearch 6.3](https://www.elastic.co/guide/en/elasticsearch/reference/6.7/release-notes-6.3.0.html#deprecation-6.3.0), the connector's corresponding setting is now also deprecated. This setting was only used for configuring the embedded Elasticsearch server, so its deprecation should have minimal impact to production deployments.
-
-**Http CORS Enabled, `httpCORSEnabled=true`** \
-Set this boolean to false to disable cross-origin resource sharing. When set to `false`, a browser on another origin cannot make requests to Elasticsearch. Web front end tools like Elasticsearch Head may be unable to connect (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).
-
-**Http CORS Allow Origin, `httpCORSAllowOrigin=/https?:\\/\\/localhost(:[0-9]+)?/`** \
-Set the String origins to allow when HTTP CORS is enabled (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).
-
-**Http CORS Configurations, `httpCORSConfigurations=`** \
-Set the String values for custom settings for HTTP CORS, in YML format (`elasticsearch.yml`) (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).
-
-**Additional Configurations, `additionalConfigurations=`** \
-Set the String values for custom settings for embedded Elasticsearch, in YML format. See: Adding Settings to the Liferay Elasticsearch Connector
+**Index Name Prefix, `indexNamePrefix="liferay-"`** \
+Set a String value to use as the prefix for the search index name. The default value should not be changed under normal conditions. If you change it, you must also perform a *re-index all* operation for the portal and then manually delete the old index using the Elasticsearch administration console.
 
 **Additional Index Configurations, `additionalIndexConfigurations=`** \
 Set the String values for custom settings for the Liferay index, in JSON or YML format (refer to the Elasticsearch Create Index API for more information).  See: Adding Settings to the Liferay Elasticsearch Connector
@@ -205,34 +132,139 @@ Set the String values for custom mappings for the `LiferayDocumentType`, in JSON
 **Override Type Mappings, `overrideTypeMappings=`** \
 Settings here override Liferay's default type mappings. This is an advanced feature that should be used only if strictly necessary. If you set this value, the default mappings used to define the Liferay Document Type in Liferay source code (for example, `liferay-type-mappings.json`) are ignored entirely, so include the whole mappings definition in this property, not just the segment you're modifying.
 
-**Proxy Host, `proxyHost`** \
+**Number of Company and System Index Replicas, `indexNumberOfReplicas=""`** \
+Set the number of replicas for each Liferay company and system index. If unset, no replicas are used. Changing this value requires a full re-index.
+
+**Number of Company and System Index Shards, `indexNumberOfShards=""`** \
+Set the number of shards to use when a Liferay company and system index is created. If unset, a single shard will be used. Changing this value requires a full re-index.
+
+[7.2-] **Transport Addresses, `transportAddresses="localhost:9300"`** \
+Set the String values for the addresses of the remote Elasticsearch nodes to connect to. This value is required when Operation Mode is set to remote (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information). Specify as many or few nodes as you see fit.
+
+[7.2-] **Client Transport Sniff, `clientTransportSniff="true"`** \
+Set this boolean to true to enable cluster sniffing and dynamically discover available data nodes in the cluster (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).
+
+[7.2-] **Client Transport Ignore Cluster Name, `clientTransportIgnoreClusterName="false"`** \
+Set this boolean to true to ignore cluster name validation of connected nodes (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).
+
+[7.2-] **Client Transport Ping Timeout, `clientTransportPingTimeout=`** \
+Set the time (in seconds) the client node waits for a ping response from a node. If unset, the default Elasticsearch `client.transport.ping_timeout` is used.
+
+[7.2-] **Client Transport Nodes Sampler Interval, `clientTransportNodesSamplerInterval=`** \
+Set this String value to instruct the client node on how often to sample / ping the nodes listed and connected (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).
+
+**Log Exceptions Only, `logExceptionsOnly="true"`** \
+A boolean setting that, when set to true, only logs exceptions from Elasticsearch, and does not re-throw them.
+
+**Track Total Hits, `trackTotalHits="true"** \
+If enabled, hits are accurately counted when there are more than 10,000 results for a search. Leaving this enabled may have an impact on performance when there is a large number of hits for a search.
+
+#### Configuring the Development Mode Server
+
+**Cluster Name, `clusterName="LiferayElasticsearchCluster"`** \
+The cluster name is only needed for the Transport Client in Liferay 7.2. Set a String value to declare the cluster to integrate with. In Liferay 7.3+, where the connection is managed through the REST client, this property is only used for naming the embedded cluster when in development mode.
+
+**Node Name, `nodeName=`** \
+Name the embedded Elasticsearch server's node. A remote Elasticsearch server's node name is configured in its `elasticsearch.yml`.
+
+**Additional Configurations, `additionalConfigurations=`** \
+Set the String values for custom settings for embedded Elasticsearch, in YML format. See: Adding Settings to the Liferay Elasticsearch Connector
+
+**Bootstrap Mlock All, `bootstrapMlockAll="false"`**
+A boolean setting that, when set to `true`, tries to lock the process address space into RAM, preventing any Elasticsearch memory from being swapped out (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/setup-configuration-memory.html#bootstrap-memory_lock)) for more information)
+
+**Http CORS Allow Origin, `httpCORSAllowOrigin="/https?:\\/\\/localhost(:[0-9]+)?/"** \
+Set the String origins to allow when HTTP CORS is enabled (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).
+
+**Http CORS Configurations, `httpCORSConfigurations=** \
+Set the String values for custom settings for HTTP CORS, in YML format (`elasticsearch.yml`) (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).
+
+**Http CORS Enabled, `httpCORSEnabled="true"** \
+Set this boolean to false to disable cross-origin resource sharing. When set to `false`, a browser on another origin cannot make requests to Elasticsearch. Web front end tools like Elasticsearch Head may be unable to connect (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).
+
+**Network Host, `networkHost=""** \
+Set this String value to instruct the node to bind to this hostname or IP address and publish (advertise) this host to other nodes in the cluster. This is a shortcut which sets the bind host and the publish host at the same time (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#common-network-settings) for more information).
+
+**Network Bind Host, `networkBindHost=""** \
+Set the String value of the network interface(s) a node should bind to in order to listen for incoming requests (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#advanced-network-settings) for more information).
+
+**Network Publish Host, `networkPublishHost=""** \
+Set the String value of a single interface that the node advertises to other nodes in the cluster, so that those nodes can connect to it (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#advanced-network-settings) for more information).
+
+**Sidecar Debug, `sidecarDebug="false"** \
+Set this to true to enable debug mode for the sidecar process.
+
+**Sidecar Debug Settings, `sidecarDebugSettings="-agentlib:jdwp=transport=dt_socket,address=8001,server=y,suspend=y,quiet=y"** \
+Set the JVM options used to debug the sidecar process.
+
+**Sidecar Heartbeat Interval, `sidecarHeartbeatInterval="10000"** \
+Set the heartbeat interval in milliseconds used to detect the health of the sidecar process.
+
+**Sidecar Home, `sidecarHome="elasticsearch7"** \
+Set the path of the sidecar base folder used to start the sidecar process.
+
+**Sidecar HTTP Port, `sidecarHttpPort="9200"** \
+This configuration only applies to Liferay 7.3 with the sidecar Elasticsearch. Set the HTTP port range of the sidecar Elasticsearch node. Set to AUTO to automatically find a port in the 9201-9300 range. If unset, the value of Embedded HTTP port (`9201` by default) is used.
+
+**Sidecar JVM Options, `sidecarJVMOptions="-Xms1g|-Xmx1g|-XX:+AlwaysPreTouch"** \
+Set the JVM options used by the sidecar process.
+
+**Sidecar Shutdown Timeout, `sidecarShutdownTimeout="10000"** \
+Set the time in milliseconds to wait before the sidecar process is forcibly shut down.
+
+**Transport Tcp Port, `transportTcpPort=""** \
+Set the String value for the port to bind for communication between nodes.  Accepts a single value or a range (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-transport.html#_tcp_transport) for more information).
+
+**Zen Discovery Unicast Hosts Port, `discoveryZenPingUnicastHostsPort="9300-9400"** \
+Set a String value for the range of ports to use when building the value for `discovery.zen.ping.unicast.hosts`. Multiple Elasticsearch nodes on a range of ports can act as gossip routers at the same computer (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-discovery-hosts-providers.html) for more information).
+
+### Properties Unique to the Elasticsearch Connections Configuration
+
+**Active, `active="false"`** \
+Activate or deactivate the connection as needed. Do not deactivate a connection if it's selected in the Elasticsearch 7 configuration's Remote Cluster Connection ID setting.
+
+**Connection ID, `connectionId=`** \
+Set a unique ID for the connection. If active, this connection becomes available to select in the Elasticsearch 7 configuration's Remote Cluster Connection ID property.
+
+### Properties Shared Between the Elasticsearch 7 and Elasticsearch Connections Configurations
+
+Configuration that would be unique depending on the defined connection are available from both the Elasticsearch 7 and the Elasticsearch Connections configurations.
+
+**Network Host Addresses, `networkHostAddresses="http://localhost:9200"** \
+Set the remote HTTP hosts to connect to. This is required in Liferay 7.3 as it configures the REST client connection.
+
+**Authentication Enabled, `authenticationEnabled="false"** \
+Enable or disable authentication to Elasticsearch with a user name and password.
+
+**Username, `username="elastic"** \
+Set the user name for authenticating to Elasticsearch if Authentication Enabled is checked.
+
+**Password, `password=** \
+Set the password for authenticating to Elasticsearch if Authentication Enabled is checked.
+
+**Http SSL Enabled, `httpSSLEnabled="false"** \
+Enable or disable TLS/SSL.
+
+**Truststore Type, `truststoreType="pkcs12"** \
+Set the truststore type if HTTP SSL Enabled is checked.
+
+**Truststore Path, `truststorePath="/path/to/localhost.p12"** \
+Set the path to the truststore file if HTTP SSL Enabled is checked.
+
+**Truststore Password, `truststorePassword=** \
+Set the password to the truststore if HTTP SSL Enabled is checked.
+
+**Proxy Host, `proxyHost=`** \
 Set the proxy host for the client connection.
 
-**Proxy Port, `proxyPort=0`** \
+**Proxy Port, `proxyPort="0"`** \
 Set the proxy port for the client connection.
 
-**Proxy Username, `proxyUserName`** \
+**Proxy Username, `proxyUserName=`** \
 Set the proxy user name for a proxy connection.
 
-**Proxy Password, `proxyPassword`** \
+**Proxy Password, `proxyPassword=`** \
 Set the password for connecting to the proxy.
-
-## Configurations only Affecting the Embedded Elasticsearch Server
-
-These settings (defined above) are only meant to use while configuring the [embedded Elasticsearch server](using-the-sidecar-or-embedded-elasticsearch.md)). Configuring these will elicit no effect on remote Elasticsearch installations:
-
-- `bootstrapMlockAll`
-- `discoveryZenPingUnicastHostsPort`
-- `networkHost`
-- `networkBindHost`
-- `networkPublishHost` 
-- `transportTcpPort` 
-- `httpEnabled`
-- `httpCORSEnabled` 
-- `httpCORSAllowOrigin` 
-- `httpCORSConfigurations` 
-
-You can configure these settings in the System Setting application, or as mentioned above, you can specify them in a deployable OSGi `.config` file.
 
 ## Related Topics
 

--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
@@ -70,7 +70,7 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | Client Transport Ping Timeout | `clientTransportPingTimeout=""` | Liferay 7.2- |
 | Client Transport Nodes Sampler Interval | `clientTransportNodesSamplerInterval=""` | Liferay 7.2- |
 | | <a href="#other-settings" id="other-settings">OTHER SETTINGS</a> |
-| Remote Cluster Connection ID | `remoteClusterConnectionId=` | Liferay 7.3+ when using LES Cross-Cluster Replication |
+| Remote Cluster Connection ID | `remoteClusterConnectionId=` | Liferay 7.3+ when using [LES Cross-Cluster Replication](../../liferay-enterprise-search/cross-cluster-replication/cross-cluster-replication.md)) |
 | | <a href="#development-mode-settings" id="development-mode-settings">DEVELOPMENT MODE SETTINGS</a> | 
 | Bootstrap Mlock All | `bootstrapMlockAll="false"` | Liferay 7.2+ |
 | Http CORS Allow Origin | `httpCORSAllowOrigin="/https?:\\/\\/localhost(:[0-9]+)?/"` | Liferay 7.2+ |

--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
@@ -48,10 +48,10 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | Index Name Prefix | `indexNamePrefix="liferay-"` | Liferay 7.2+ |
 | 7.3.x&rarr;Number of Company and System Index Replicas<br />7.2.x&rarr;Index Number of Replicas | `indexNumberOfReplicas="0-all"`<details><summary>Description</summary>Set the number of replicas for each Liferay company and system index. If unset, no replicas are used. Changing this value requires a full re-index. The default value is defined in a file called "index-settings-defaults.json" shipped with the connector.</details> | Liferay 7.2+ |
 | 7.3.x&rarr;Number of Company and System Index Shards<br />7.2.x&rarr;Index Number of Shards | `indexNumberOfShards="1"`<details><summary>Description</summary>Set the number of shards to use when a Liferay company and system index is created. If unset, a single shard will be used. Changing this value requires a full re-index. The default value is defined in a file called "index-settings-defaults.json" shipped with the connector.</details> | Liferay 7.2+ |
-| Log Exceptions Only | `logExceptionsOnly="true"` | Liferay 7.2+ |
+| Log Exceptions Only | `logExceptionsOnly=B"true"` | Liferay 7.2+ |
 | Retry On Conflict | `retryOnConflict="5"` | Liferay 7.2- |
 | | *SECURITY SETTINGS* |
-| Authentication Enabled | `authenticationEnabled="false"` | Liferay 7.3+ |
+| Authentication Enabled | `authenticationEnabled=B"false"` | Liferay 7.3+ |
 | Username | `username="elastic"` | Liferay 7.3+ |
 | Password | `password=""` | Liferay 7.3+ |
 | Http SSL Enabled | `httpSSLEnabled="false"` | Liferay 7.3+ |
@@ -77,12 +77,12 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | Bootstrap Mlock All | `bootstrapMlockAll="false"` | Liferay 7.2+ |
 | Http CORS Allow Origin | `httpCORSAllowOrigin="/https?:\\/\\/localhost(:[0-9]+)?/"` | Liferay 7.2+ |
 | Http CORS Configurations | `httpCORSConfigurations=` | Liferay 7.2+ |
-| Http CORS Enabled | `httpCORSEnabled="true"` | Liferay 7.2+ |
+| Http CORS Enabled | `httpCORSEnabled=B"true"` | Liferay 7.2+ |
 | Network Host | `networkHost=""` | Liferay 7.2+  |
 | Network Bind Host | `networkBindHost=""` | Liferay 7.2+ |
 | Network Publish Host | `networkPublishHost=""` | Liferay 7.2+ |
 | Node Name | `nodeName=` | Liferay 7.3+ |
-| Sidecar Debug | `sidecarDebug="false"` | Liferay 7.3+ |
+| Sidecar Debug | `sidecarDebug=B"false"` | Liferay 7.3+ |
 | Sidecar Debug Settings | `sidecarDebugSettings="-agentlib:jdwp=transport=dt_socket,address=8001,server=y,suspend=y,quiet=y"` | Liferay 7.3+ |
 | Sidecar Heartbeat Interval | `sidecarHeartbeatInterval="10000"` | Liferay 7.3+ |
 | Sidecar Home | `sidecarHome="elasticsearch7"` | Liferay 7.3+ |
@@ -103,7 +103,7 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | | *DEPRECATED* |
 | Operation Mode | `operationMode="EMBEDDED"` | Deprecated in Liferay 7.3, replaced with _Production Mode Enabled_  |
 | Embedded HTTP Port | `embeddedHttpPort="9201"` | Deprecated in Liferay 7.3.x |
-| Http Enabled | `httpEnabled="true"` | Deprecated in Liferay 7.1.x<br />Deprecated Elasticsearch 6.3.x |
+| Http Enabled | `httpEnabled=B"true"` | Deprecated in Liferay 7.1.x<br />Deprecated Elasticsearch 6.3.x |
 
 ## Property Descriptions
 

--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
@@ -58,7 +58,7 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | Client Transport Ping Timeout | `clientTransportPingTimeout=""` | Liferay 7.2- |
 | Client Transport Nodes Sampler Interval | `clientTransportNodesSamplerInterval=""` | Liferay 7.2- |
 | | <a href="#other-settings" id="other-settings">OTHER SETTINGS</a> |
-| Remote Cluster Connection ID | `remoteClusterConnectionId=` | Liferay 7.3+ when using [LES Cross-Cluster Replication](../../liferay-enterprise-search/cross-cluster-replication/cross-cluster-replication.md)) |
+| Remote Cluster Connection ID | `remoteClusterConnectionId=` | Liferay 7.3+ when using [LES Cross-Cluster Replication](../../liferay-enterprise-search/cross-cluster-replication/cross-cluster-replication.md) |
 | | <a href="#development-mode-settings" id="development-mode-settings">DEVELOPMENT MODE SETTINGS</a> | 
 | Bootstrap Mlock All | `bootstrapMlockAll="false"` | Liferay 7.2+ |
 | Http CORS Allow Origin | `httpCORSAllowOrigin="/https?:\\/\\/localhost(:[0-9]+)?/"` | Liferay 7.2+ |

--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
@@ -30,7 +30,7 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | ----------------------------- | ------------------------------------------------------------------------------ | ------------ | 
 | | <a href="#general-connection-settings" id="general-connection-settings">GENERAL CONNECTION SETTINGS</a> |
 | Track Total Hits | `trackTotalHits=B"true"`<details><summary>Description</summary>If enabled, hits are accurately counted when there are more than 10,000 results for a search. Leaving this enabled may have an impact on performance when there is a large number of hits for a search.</details> | Liferay 7.2+<br />(Connector to Elasticsearch 7) |
-| Production Mode Enabled | `productionModeEnabled=B"false"` | Liferay 7.3+ |
+  | Production Mode Enabled | `productionModeEnabled=B"false"`<details><summary>Description</summary>Enable production mode. In Liferay 7.3, <code>productionModeEnabled</code> replaces the deprecated setting <code>operationMode</code>. If this is checked, production mode is enabled and the Operation Mode configuration is ignored. Enabling production mode requires connecting to a remote standalone Elasticsearch cluster. If left disabled, the Operation Mode configuration is used.</details> | Liferay 7.3+ |
 | Index Name Prefix | `indexNamePrefix="liferay-"` | Liferay 7.2+ |
 | 7.3.x&rarr;Number of Company and System Index Replicas<br />7.2.x&rarr;Index Number of Replicas | `indexNumberOfReplicas="0-all"`<details><summary>Description</summary>Set the number of replicas for each Liferay company and system index. If unset, no replicas are used. Changing this value requires a full re-index. The default value is defined in a file called "index-settings-defaults.json" shipped with the connector.</details> | Liferay 7.2+ |
 | 7.3.x&rarr;Number of Company and System Index Shards<br />7.2.x&rarr;Index Number of Shards | `indexNumberOfShards="1"`<details><summary>Description</summary>Set the number of shards to use when a Liferay company and system index is created. If unset, a single shard will be used. Changing this value requires a full re-index. The default value is defined in a file called "index-settings-defaults.json" shipped with the connector.</details> | Liferay 7.2+ |
@@ -105,9 +105,6 @@ Many of the connection settings are only found in the Elasticsearch 7 configurat
 
 #### Defining the Remote Connection
 
-**Production Mode Enabled, `productionModeEnabled="false"`** \
-Enable production mode. In Liferay 7.3, `productionModeEnabled` replaces the deprecated setting `operationMode`. If this is checked, production mode is enabled and the Operation Mode configuration is ignored. Enabling production mode requires connecting to a remote standalone Elasticsearch cluster. If left disabled, the Operation Mode configuration is used.
-
 **Operation Mode, `operationMode="EMBEDDED"`** \
 There are two operation modes you can choose from: EMBEDDED or REMOTE. Set to REMOTE to connect to a remote standalone Elasticsearch cluster. Set to EMBEDDED to start Liferay with an internal Elasticsearch instance. EMBEDDED operation mode is unsupported for production environments and can be considered a "development mode" feature.
 
@@ -128,12 +125,6 @@ Set the String values for custom mappings for the `LiferayDocumentType`, in JSON
 **Override Type Mappings, `overrideTypeMappings=`** \
 Settings here override Liferay's default type mappings. This is an advanced feature that should be used only if strictly necessary. If you set this value, the default mappings used to define the Liferay Document Type in Liferay source code (for example, `liferay-type-mappings.json`) are ignored entirely, so include the whole mappings definition in this property, not just the segment you're modifying.
 
-**Number of Company and System Index Replicas, `indexNumberOfReplicas=""`** \
-Set the number of replicas for each Liferay company and system index. If unset, no replicas are used. Changing this value requires a full re-index.
-
-**Number of Company and System Index Shards, `indexNumberOfShards=""`** \
-Set the number of shards to use when a Liferay company and system index is created. If unset, a single shard will be used. Changing this value requires a full re-index.
-
 [7.2-] **Transport Addresses, `transportAddresses="localhost:9300"`** \
 Set the String values for the addresses of the remote Elasticsearch nodes to connect to. This value is required when Operation Mode is set to remote (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information). Specify as many or few nodes as you see fit.
 
@@ -151,9 +142,6 @@ Set this String value to instruct the client node on how often to sample / ping 
 
 **Log Exceptions Only, `logExceptionsOnly="true"`** \
 A boolean setting that, when set to true, only logs exceptions from Elasticsearch, and does not re-throw them.
-
-**Track Total Hits, `trackTotalHits="true"** \
-If enabled, hits are accurately counted when there are more than 10,000 results for a search. Leaving this enabled may have an impact on performance when there is a large number of hits for a search.
 
 #### Configuring the Development Mode Server
 

--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
@@ -18,7 +18,7 @@ Most of the time, the last released connector on Marketplace for one DXP version
 
 The connection to Elasticsearch is primarily defined in the _Elasticsearch 6/7_ configuration entry in System Settings (or via [corresponding configuration file](#elasticsearch-connection-configuration-entries)). Liferay 7.3 introduced the possibility to define multiple connections to Elasticsearch, through the [factory configuration](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-factory-configuration.md) _Elasticsearch Connections_ configuration. Both configuration entries are configurable through [System Settings](../../../system-administration/configuring-liferay/system-settings.md) or an [OSGi configuration file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md) (recommended: use config files). 
 
-## Configuration Files and System Settings Entries
+## System Settings Entries & Config Files
 
 | Connecting Servers | <div style="width:380px">System Settings Entry/Configuration File</div> |
 | --------------- | -------------------------------------- | 
@@ -38,11 +38,9 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 
 ## System Settings & Config File Properties
 
-[**Click here to jump to the property descriptions.**](#property-descriptions)
-
-| System Settings UI Field Name | <div style="width:280px">Configuration File Property Name, Default Value & Description | Available in |
-| ----------------------------- | -------------------------------------------------------------------------------------- | ------------ | 
-| | GENERAL CONNECTION SETTINGS |
+| System Settings UI Field Name | <div style="width:280px">Configuration File Usage, Default Value & Description | Available in |
+| ----------------------------- | ------------------------------------------------------------------------------ | ------------ | 
+| | <a href="#general-connection-settings" id="general-connection-settings">GENERAL CONNECTION SETTINGS</a> |
 | Track Total Hits | `trackTotalHits=B"true"`<details><summary>Description</summary>If enabled, hits are accurately counted when there are more than 10,000 results for a search. Leaving this enabled may have an impact on performance when there is a large number of hits for a search.</details> | Liferay 7.2+<br />(Connector to Elasticsearch 7) |
 | Production Mode Enabled | `productionModeEnabled=B"false"` | Liferay 7.3+ |
 | Index Name Prefix | `indexNamePrefix="liferay-"` | Liferay 7.2+ |
@@ -50,7 +48,7 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | 7.3.x&rarr;Number of Company and System Index Shards<br />7.2.x&rarr;Index Number of Shards | `indexNumberOfShards="1"`<details><summary>Description</summary>Set the number of shards to use when a Liferay company and system index is created. If unset, a single shard will be used. Changing this value requires a full re-index. The default value is defined in a file called "index-settings-defaults.json" shipped with the connector.</details> | Liferay 7.2+ |
 | Log Exceptions Only | `logExceptionsOnly=B"true"` | Liferay 7.2+ |
 | Retry On Conflict | `retryOnConflict="5"` | Liferay 7.2- |
-| | *SECURITY SETTINGS* |
+| | <a href="#security-settings" id="security-settings">SECURITY SETTINGS</a> |
 | Authentication Enabled | `authenticationEnabled=B"false"` | Liferay 7.3+ |
 | Username | `username="elastic"` | Liferay 7.3+ |
 | Password | `password=""` | Liferay 7.3+ |
@@ -58,22 +56,22 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | Truststore Type | `truststoreType="pkcs12"` | Liferay 7.3+ |
 | Truststore Path | `truststorePath="/path/to/localhost.p12"` | Liferay 7.3+ |
 | Truststore Password | `truststorePassword=""` | Liferay 7.3+ |
-| | *ELASTICSEARCH CONNECTIONS SETTINGS* |
+| | <a href="#elasticsearch-connections-settings" id="elasticsearch-connections-settings">ELASTICSEARCH CONNECTIONS SETTINGS</a> |
 | Active | `active=B"false"` | Liferay 7.3+ |
 | Connection ID | `connectionId=""` | Liferay 7.3+ |
-| | *CONNECTION DECLARATION SETTINGS* |
-| Remote Cluster Connection ID | `remoteClusterConnectionId=` | Liferay 7.3+ if using the `ElasticsearchConnectionConfiguration` |
-| | *REST CLIENT SETTINGS* |
+| | <a href="#rest-client-settings" id="rest-client-settings">REST CLIENT SETTINGS</a> |
 | Network Host Addresses | `networkHostAddresses="[http://localhost:9200]"` | Liferay 7.3+ |
 | REST Client Logger Level | `RESTClientLoggerLevel="ERROR"` | Liferay 7.3+ |
-| | *TRANSPORT CLIENT SETTINGS* |
+| | <a href="#transport-client-settings" id="transport-client-settings">TRANSPORT CLIENT SETTINGS</a> |
 | Cluster Name | `clusterName="LiferayElasticsearchCluster"` | Liferay 7.2-<br />On 7.3+, applies to development mode |
 | Transport Addresses | `transportAddresses=["localhost:9300"]` | Liferay 7.2- |
 | Client Transport Sniff | `clientTransportSniff=B"true"` | Liferay 7.2- |
 | Client Transport Ignore Cluster Name | `clientTransportIgnoreClusterName=B"false"` | Liferay 7.2- |
 | Client Transport Ping Timeout | `clientTransportPingTimeout=""` | Liferay 7.2- |
 | Client Transport Nodes Sampler Interval | `clientTransportNodesSamplerInterval=""` | Liferay 7.2- |
-| | *DEVELOPMENT MODE SETTINGS* | 
+| | <a href="#other-settings" id="other-settings">OTHER SETTINGS</a> |
+| Remote Cluster Connection ID | `remoteClusterConnectionId=` | Liferay 7.3+ when using LES Cross-Cluster Replication |
+| | <a href="#development-mode-settings" id="development-mode-settings">DEVELOPMENT MODE SETTINGS</a> | 
 | Bootstrap Mlock All | `bootstrapMlockAll="false"` | Liferay 7.2+ |
 | Http CORS Allow Origin | `httpCORSAllowOrigin="/https?:\\/\\/localhost(:[0-9]+)?/"` | Liferay 7.2+ |
 | Http CORS Configurations | `httpCORSConfigurations=` | Liferay 7.2+ |
@@ -91,7 +89,7 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | Sidecar Shutdown Timeout | `sidecarShutdownTimeout="10000"` | Liferay 7.3+ |
 | Transport Tcp Port | `transportTcpPort=""` | Liferay 7.2+ |
 | Zen Discovery Unicast Hosts Port | `discoveryZenPingUnicastHostsPort="9300-9400"` | Liferay 7.2+ |
-| | ADVANCED CONFIGURATION |
+| | <a href="#advanced-settings" id="advanced-settings">ADVANCED SETTINGS</a> |
 | Additional Configurations | `additionalConfigurations=""` | Liferay 7.2+ |
 | Additional Index Configurations | `additionalIndexConfigurations=""` | Liferay 7.2+ |
 | Additional Type Mappings | `additionalTypeMappings=""` | Liferay 7.2+ |
@@ -100,10 +98,10 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | Proxy Port | `proxyPort="0"` | Liferay DXP 7.3 FP1+/SP1+ and Liferay Portal CE GA7+ |
 | Proxy Username | `proxyUserName=""` | Liferay DXP 7.3 FP1+/SP1+ and Liferay Portal CE GA7+ |
 | Proxy Password | `proxyPassword=""` | Liferay DXP 7.3 FP1+/SP1+ and Liferay Portal CE GA7+ |
-| | *DEPRECATED* |
-| Operation Mode | `operationMode="EMBEDDED"` | Deprecated in Liferay 7.3, replaced with _Production Mode Enabled_  |
-| Embedded HTTP Port | `embeddedHttpPort="9201"` | Deprecated in Liferay 7.3.x |
-| Http Enabled | `httpEnabled=B"true"` | Deprecated in Liferay 7.1.x<br />Deprecated Elasticsearch 6.3.x |
+| | <a href="#deprecated-settings" id="deprecated-settings">DEPRECATED</a> |
+| Operation Mode | `operationMode="EMBEDDED"` | Deprecated as of Liferay 7.3, replaced with _Production Mode Enabled_  |
+| Embedded HTTP Port | `embeddedHttpPort="9201"` | Deprecated as of Liferay 7.3.x |
+| Http Enabled | `httpEnabled=B"true"` | Deprecated as of Liferay 7.1.x<br />Deprecated Elasticsearch 6.3.x |
 
 ## Property Descriptions
 

--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
@@ -1,8 +1,81 @@
 # Elasticsearch Connection Settings
 
-Elasticsearch is Liferay's default search engine. The connection to Elasticsearch is managed through the Liferay Connector to Elasticsearch [Version].
+Elasticsearch is Liferay's default search engine. The connection to Elasticsearch is primarily defined in the Elasticsearch 6/7 configuration entry in System Settings (or via corresponding configuration file). Liferay 7.3 introduced the possibility to define multiple connections to Elasticsearch, through the [factory configuration](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-factory-configuration.md) Elasticsearch Connections configuration. Both configuration entries are configurable through [System Settings](../../../system-administration/configuring-liferay/system-settings.md) or an [OSGi configuration file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md). 
 
-The connection is primarily defined in the Elasticsearch 6/7 configuration entry in System Settings (or via corresponding configuration file). Liferay 7.3 introduced the possibility to define multiple connections to Elasticsearch, through the [factory configuration](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-factory-configuration.md) Elasticsearch Connections configuration. Both configuration entries are configurable through [System Settings](../../../system-administration/configuring-liferay/system-settings.md) or an [OSGi configuration file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md). 
+<!-- If we like these tables, they'll require reorganization -->
+**Configuration Files and System Settings Entries:**
+
+| Server Versions | Configuration File Name | System Settings Entry |
+| --------------- | ----------------------- | --------------------- |
+| Liferay 7.2.x<br />Elasticsearch 6.x           | `com.liferay.portal.search.elasticsearch6.configuration.ElasticsearchConfiguration.config` | Elasticsearch 6 |
+| Liferay 7.2.x<br />Elasticsearch 7.x           | `com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config` | Elasticsearch 7
+| Liferay 7.3.x<br />Elasticsearch 7.x           | `com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config`<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConnectionConfiguration-[key].config` | Elasticsearch 7<br /><br /><br /><br /><br />Elasticsearch Connections (factory) |
+
+**Configuration Properties Overview:**
+
+| **System Settings Configuration Label** | **Configuration File Field Name**<br />(default value) | **Liferay/Elasticsearch Version Details** |
+| ----------------------------------- | -------------------------------------------------- | --------------- | 
+| | *SECURITY SETTINGS* |
+| Authentication Enabled | `authenticationEnabled` | Liferay 7.3+ |
+| Username | `username` | Liferay 7.3+ |
+| Password | `password` | Liferay 7.3+ |
+| Http SSL Enabled | `httpSSLEnabled` | Liferay 7.3+ |
+| Truststore Type | `truststoreType` | Liferay 7.3+ |
+| Truststore Path | `truststorePath` | Liferay 7.3+ |
+| Truststore Password | `truststorePassword` | |
+| | *ELASTICSEARCH CONNECTIONS SETTINGS* |
+| Active | `active="false"` | Liferay 7.3+ |
+| Connection ID | `connectionId=` | Liferay 7.3+ |
+| | *CONNECTION DECLARATION SETTINGS* |
+| Remote Cluster Connection ID | `remoteClusterConnectionId` | Liferay 7.3+ if using the `ElasticsearchConnectionConfiguration` |
+| | *REST CLIENT SETTINGS* |
+| Network Host Addresses | `networkHostAddresses=http://localhost:9200` | Liferay 7.3+ |
+| | *TRANSPORT CLIENT SETTINGS* |
+| Cluster Name | `clusterName=LiferayElasticsearchCluster` | Liferay 7.2-<br />On 7.3+, applies only to development mode |
+| Transport Addresses | `transportAddresses=localhost:9300` | Liferay 7.2- |
+| Client Transport Sniff | `clientTransportSniff=true` | |
+| Client Transport Ignore Cluster Name | `clientTransportIgnoreClusterName=false` | |
+| Client Transport Ping Timeout | `clientTransportPingTimeout=` | |
+| Client Transport Nodes Sampler Interval | `clientTransportNodesSamplerInterval=` | |
+| | *DEVELOPMENT MODE SETTINGS* | 
+| Additional Configurations | `additionalConfigurations=` | Liferay 7.2+ |
+| Bootstrap Mlock All | `bootstrapMlockAll=false` | Liferay 7.2+ |
+| Http CORS Allow Origin | `httpCORSAllowOrigin=/https?:\\/\\/localhost(:[0-9]+)?/` | |
+| Http CORS Configurations | `httpCORSConfigurations=` | |
+| Http CORS Enabled | `httpCORSEnabled=true` | |
+| Network Host | `networkHost=` | Liferay 7.2+  |
+| Network Bind Host | `networkBindHost=` | Liferay 7.2+ |
+| Network Publish Host | `networkPublishHost=` | Liferay 7.2+ |
+| Sidecar Debug | `sidecarDebug` | Liferay 7.3+ |
+| Sidecar Debug Settings | `sidecarDebugSettings` | Liferay 7.3+ |
+| Sidecar Heartbeat Interval | `sidecarHeartbeatInterval` | Liferay 7.3+ |
+| Sidecar Home | `sidecarHome` | Liferay 7.3+ |
+| Sidecar HTTP Port | `sidecarHttpPort=9200` | Liferay 7.3+ |
+| Sidecar JVM Options | `sidecarJVMOptions` | Liferay 7.3+ |
+| Sidecar Shutdown Timeout | `sidecarShutdownTimeout` | Liferay 7.3+ |
+| Transport Tcp Port | `transportTcpPort=` | Liferay 7.2+ |
+| Zen Discovery Unicast Hosts Port | `discoveryZenPingUnicastHostsPort=9300-9400` | Liferay 7.2+ |
+| | GENERAL CONNECTION SETTINGS |
+| Node Name | `nodeName` | Liferay 7.3+ |
+| Track Total Hits | `trackTotalHits` | Liferay 7.2+ |
+| Production Mode Enabled | `productionModeEnabled="false"` | Liferay 7.3+ |
+| Index Name Prefix | `indexNamePrefix=liferay-` | Liferay 7.2+ |
+| 7.3.x&rarr;Number of Company and System Index Replicas<br />7.2.x&rarr;Index Number of Replicas | `indexNumberOfReplicas=` | Liferay 7.2+ |
+| 7.3.x&rarr;Number of Company and System Index Shards<br />7.2.x&rarr;Index Number of Shards | `indexNumberOfShards=` | Liferay 7.2+ |
+| Log Exceptions Only | `logExceptionsOnly=true` | Liferay 7.2+ |
+| Retry On Conflict | `retryOnConflict=5` | Liferay 7.2+ |
+| | ADVANCED CONFIGURATION |
+| Additional Index Configurations | `additionalIndexConfigurations=` | Liferay 7.2+ |
+| Additional Type Mappings | `additionalTypeMappings=` | Liferay 7.2+ |
+| Override Type Mappings | `overrideTypeMappings=` | Liferay 7.2+ |
+| Proxy Host | `proxyHost` | Liferay 7.3+ |
+| Proxy Port | `proxyPort=0` | Liferay 7.3+ |
+| Proxy Username | `proxyUserName` | Liferay 7.3+ |
+| Proxy Password | `proxyPassword` | Liferay 7.3+ |
+| | *DEPRECATED* |
+| Operation Mode | `operationMode="EMBEDDED"` | Deprecated in Liferay 7.3.x |
+| Embedded HTTP Port | `embeddedHttpPort=9201` | Deprecated in Liferay 7.3.x |
+| Http Enabled | `httpEnabled=true` | Deprecated in Liferay 7.1.x<br />Deprecated Elasticsearch 6.3.x |
 
 ## Elasticsearch Connection Configuration Files
 
@@ -36,103 +109,116 @@ The configuration settings listed are for Liferay's Elasticsearch connector as o
 
 ### Properties Unique to the Elasticsearch 7 Configuration
 
-**Production Mode Enabled, `productionModeEnabled="false"`**
+**Production Mode Enabled, `productionModeEnabled="false"`** \
 Enable production mode. In Liferay 7.3, `productionModeEnabled` replaces the deprecated setting `operationMode`. If this is checked, production mode is enabled and the Operation Mode configuration is ignored. Enabling production mode requires connecting to a remote standalone Elasticsearch cluster. If left disabled, the Operation Mode configuration is used.
 
-[Deprecated] **Operation Mode, `operationMode="EMBEDDED"`**
+[Deprecated] **Operation Mode, `operationMode="EMBEDDED"`** \
 There are two operation modes you can choose from: EMBEDDED or REMOTE. Set to REMOTE to connect to a remote standalone Elasticsearch cluster. Set to EMBEDDED to start Liferay with an internal Elasticsearch instance. EMBEDDED operation mode is unsupported for production environments.
 
-**Remote Cluster Connection ID, `remoteClusterConnectionID`**
+**Remote Cluster Connection ID, `remoteClusterConnectionId`** \
 Choose the connection ID for a connection to the remote Elasticsearch cluster. The available connections are defined in the Elasticsearch Connections System Settings entry. If this value is not set then the connection configurations in the Elasticsearch 7 entry are used for the remote cluster connection.
 
 <!-- embedded only on 7.3 -->
-**Cluster Name, `clusterName=LiferayElasticsearchCluster`**
+**Cluster Name, `clusterName=LiferayElasticsearchCluster`** \
 A String value that sets the name of the cluster to integrate with. This name should match the remote cluster when Operation Mode is set to remote.  (See also: remote operation mode)
+
 
 ### Properties Unique to the Elasticsearch Connections Configuration
 
-**Active, `active="false"`**
+**Active, `active="false"`** \
 
-**Connection ID, `connectionId=`**
+**Connection ID, `connectionId=`** \
 Set a unique ID for the connection. This is referenced in the Elasticsearch 7 property Remote Cluster Connection ID.
 
 ### Properties Shared Between the Elasticsearch 7 and Elasticsearch Connections Configurations
 
-**Index Name Prefix, `indexNamePrefix=liferay-`**
+**Index Name Prefix, `indexNamePrefix=liferay-`** \
 Set a String value to use as the prefix for the search index name. The default value should not be changed under normal conditions. If you change it, you must also perform a *reindex all* operation for the portal and then manually delete the old index using the Elasticsearch administration console.
 
-**Index Number of Replicas, `indexNumberOfReplicas=`**
+**Index Number of Replicas, `indexNumberOfReplicas=`** \
 Set the number of replicas for each index. If left unset, no replicas are used.  A full reindex is required to make changes take effect.
 
-**Index Number of Shards, `indexNumberOfShards=`**
+**Index Number of Shards, `indexNumberOfShards=`** \
 Set the number of index shards to use when a Liferay index is created. If left unset, a single shard is used. A full reindex is required to make changes take effect. 
 
-**Bootstrap Mlock All, `bootstrapMlockAll=false`**
+**Bootstrap Mlock All, `bootstrapMlockAll=false`** \
 A boolean setting that, when set to `true`, tries to lock the process address space into RAM, preventing any Elasticsearch memory from being swapped out (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/setup-configuration-memory.html#bootstrap-memory_lock)) for more information)
 
-**Log Exceptions Only, `logExceptionsOnly=true`**
+**Log Exceptions Only, `logExceptionsOnly=true`** \
 A boolean setting that, when set to true, only logs exceptions from Elasticsearch, and does not rethrow them.
 
-**Retry On Conflict, `retryOnConflict=5`**
+**Retry On Conflict, `retryOnConflict=5`** \
 Set an int value for the number of retries to attempt if a version conflict occurs because the document was updated between getting it and updating it (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/docs-update.html#docs-update-api-query-params) for more information).
 
-**Discovery Zen Ping Unicast Hosts Port, `discoveryZenPingUnicastHostsPort=9300-9400`**
+**Discovery Zen Ping Unicast Hosts Port, `discoveryZenPingUnicastHostsPort=9300-9400`** \
 Set a String value for the range of ports to use when building the value for discovery.zen.ping.unicast.hosts. Multiple Elasticsearch nodes on a range of ports can act as gossip routers at the same computer (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-discovery-hosts-providers.html) for more information).
 
-**Network Host, `networkHost=`**
+**Network Host, `networkHost=`** \
 Set this String value to instruct the node to bind to this hostname or IP address and publish (advertise) this host to other nodes in the cluster. This is a shortcut which sets the bind host and the publish host at the same time (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#common-network-settings) for more information).
 
-**Network Bind Host, `networkBindHost=`**
+**Network Bind Host, `networkBindHost=`** \
 Set the String value of the network interface(s) a node should bind to in order to listen for incoming requests (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#advanced-network-settings) for more information).
 
-**Network Publish Host, `networkPublishHost=`**
+**Network Publish Host, `networkPublishHost=`** \
 Set the String value of a single interface that the node advertises to other nodes in the cluster, so that those nodes can connect to it (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#advanced-network-settings) for more information).
 
-**Transport Tcp Port, `transportTcpPort=`**
+**Transport Tcp Port, `transportTcpPort=`** \
 Set the String value for the port to bind for communication between nodes.  Accepts a single value or a range (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-transport.html#_tcp_transport) for more information).
 
-**Transport Addresses, `transportAddresses=localhost:9300`**
+**Transport Addresses, `transportAddresses=localhost:9300`** \
 Set the String values for the addresses of the remote Elasticsearch nodes to connect to. This value is required when Operation Mode is set to remote (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information). Specify as many or few nodes as you see fit.
 
-**Client Transport Sniff, `clientTransportSniff=true`**
+**Client Transport Sniff, `clientTransportSniff=true`** \
 Set this boolean to true to enable cluster sniffing and dynamically discover available data nodes in the cluster (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).
 
-**Client Transport Ignore Cluster Name, `clientTransportIgnoreClusterName=false`**
+**Client Transport Ignore Cluster Name, `clientTransportIgnoreClusterName=false`** \
 Set this boolean to true to ignore cluster name validation of connected nodes (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).
 
-**Client Transport Ping Timeout, `clientTransportPingTimeout=`**
-e time (in seconds) the client node waits for a ping response from a node. If unset, the default Elasticsearch `client.transport.ping_timeout` is used.
+**Client Transport Ping Timeout, `clientTransportPingTimeout=`** \
+Set the time (in seconds) the client node waits for a ping response from a node. If unset, the default Elasticsearch `client.transport.ping_timeout` is used.
 
-**Client Transport Nodes Sampler Interval, `clientTransportNodesSamplerInterval=`**
+**Client Transport Nodes Sampler Interval, `clientTransportNodesSamplerInterval=`** \
 Set this String value to instruct the client node on how often to sample / ping the nodes listed and connected (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).
 
-**Http Enabled, `httpEnabled=true`**
-Set this boolean to false to disable the http layer entirely on nodes which are not meant to serve REST requests directly. As this setting was [deprecated in Elasticsearch 6.3](https://www.elastic.co/guide/en/elasticsearch/reference/6.7/release-notes-6.3.0.html#deprecation-6.3.0), the connector's corresponding setting is now also deprecated. This setting was only used for configuring the embedded Elasticsearch server, so its deprecation should have minimal impact to production deployments.
+**Http Enabled, `httpEnabled=true`** \
+Set this boolean to false to disable the HTTP layer entirely on nodes which are not meant to serve REST requests directly. As this setting was [deprecated in Elasticsearch 6.3](https://www.elastic.co/guide/en/elasticsearch/reference/6.7/release-notes-6.3.0.html#deprecation-6.3.0), the connector's corresponding setting is now also deprecated. This setting was only used for configuring the embedded Elasticsearch server, so its deprecation should have minimal impact to production deployments.
 
-**Http CORS Enabled, `httpCORSEnabled=true`**
-Set this boolean to false to disable cross-origin resource sharing, i.e. whether a browser on another origin can do requests to Elasticsearch. If disabled, web front end tools like elasticsearch-head may be unable to connect (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).
+**Http CORS Enabled, `httpCORSEnabled=true`** \
+Set this boolean to false to disable cross-origin resource sharing. When set to `false`, a browser on another origin cannot make requests to Elasticsearch. Web front end tools like Elasticsearch Head may be unable to connect (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).
 
-**Http CORS Allow Origin, `httpCORSAllowOrigin=/https?:\\/\\/localhost(:[0-9]+)?/`**
+**Http CORS Allow Origin, `httpCORSAllowOrigin=/https?:\\/\\/localhost(:[0-9]+)?/`** \
 Set the String origins to allow when HTTP CORS is enabled (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).
 
-**Http CORS Configurations, `httpCORSConfigurations=`**
+**Http CORS Configurations, `httpCORSConfigurations=`** \
 Set the String values for custom settings for HTTP CORS, in YML format (`elasticsearch.yml`) (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).
 
-**Additional Configurations, `additionalConfigurations=`**
+**Additional Configurations, `additionalConfigurations=`** \
 Set the String values for custom settings for embedded Elasticsearch, in YML format. See: Adding Settings to the Liferay Elasticsearch Connector
 
-**Additional Index Configurations, `additionalIndexConfigurations=`**
+**Additional Index Configurations, `additionalIndexConfigurations=`** \
 Set the String values for custom settings for the Liferay index, in JSON or YML format (refer to the Elasticsearch Create Index API for more information).  See: Adding Settings to the Liferay Elasticsearch Connector
 
-**Additional Type Mappings, `additionalTypeMappings=`**
+**Additional Type Mappings, `additionalTypeMappings=`** \
 Set the String values for custom mappings for the `LiferayDocumentType`, in JSON format (refer to the Elasticsearch Put Mapping API for more information) See: Adding Settings to the Liferay Elasticsearch Connector
 
-**Override Type Mappings, `overrideTypeMappings=`**
-ttings here override @product@'s default type mappings. This is an advanced feature that should be used only if strictly necessary. If you set this value, the default mappings used to define the Liferay Document Type in @product@ source code (for example, `liferay-type-mappings.json`) are ignored entirely, so include the whole mappings definition in this property, not just the segment you're modifying.
+**Override Type Mappings, `overrideTypeMappings=`** \
+Settings here override Liferay's default type mappings. This is an advanced feature that should be used only if strictly necessary. If you set this value, the default mappings used to define the Liferay Document Type in Liferay source code (for example, `liferay-type-mappings.json`) are ignored entirely, so include the whole mappings definition in this property, not just the segment you're modifying.
+
+**Proxy Host, `proxyHost`** \
+Set the proxy host for the client connection.
+
+**Proxy Port, `proxyPort=0`** \
+Set the proxy port for the client connection.
+
+**Proxy Username, `proxyUserName`** \
+Set the proxy user name for a proxy connection.
+
+**Proxy Password, `proxyPassword`** \
+Set the password for connecting to the proxy.
 
 ## Configurations only Affecting the Embedded Elasticsearch Server
 
-These settings (defined above) are only meant to use while configuring the [embedded Elasticsearch server]((using-the-sidecar-or-embedded-elasticsearch.md)). Configuring these will elicit no effect on remote Elasticsearch installations:
+These settings (defined above) are only meant to use while configuring the [embedded Elasticsearch server](using-the-sidecar-or-embedded-elasticsearch.md)). Configuring these will elicit no effect on remote Elasticsearch installations:
 
 - `bootstrapMlockAll`
 - `discoveryZenPingUnicastHostsPort`

--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
@@ -34,7 +34,7 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | 7.3.x&rarr;Number of Company and System Index Replicas<br />7.2.x&rarr;Index Number of Replicas | <details><summary>`indexNumberOfReplicas="0-all"`</summary>Set the number of replicas for each Liferay company and system index. If unset, no replicas are used. Changing this value requires a full re-index. The default value is defined in a file called "index-settings-defaults.json" shipped with the connector.</details> | Liferay 7.2+ |
 | 7.3.x&rarr;Number of Company and System Index Shards<br />7.2.x&rarr;Index Number of Shards | <details><summary>`indexNumberOfShards="1"`</summary>Set the number of shards to use when a Liferay company and system index is created. If unset, a single shard will be used. Changing this value requires a full re-index. The default value is defined in a file called "index-settings-defaults.json" shipped with the connector.</details> | Liferay 7.2+ |
 | Log Exceptions Only | <details><summary>`logExceptionsOnly=B"true"`</summary>A boolean setting that, when set to true, only logs exceptions from Elasticsearch, and does not re-throw them.</details> | Liferay 7.2+ |
-| Retry On Conflict | <details><summary>`retryOnConflict="5"`</summary></details> | Liferay 7.2- |
+| Retry On Conflict | <details><summary>`retryOnConflict="5"`</summary>Set an int value for the number of retries to attempt if a version conflict occurs because the document was updated between getting it and updating it (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/docs-update.html#docs-update-api-query-params) for more information.</details> | Liferay 7.2- |
 | | <a href="#security-settings" id="security-settings">SECURITY SETTINGS</a> |
 | Authentication Enabled | <details><summary>`authenticationEnabled=B"false"`</summary>Enable or disable authentication to Elasticsearch with a user name and password.</details> | Liferay 7.3+ |
 | Username | <details><summary>`username="elastic"`</summary>Set the user name for authenticating to Elasticsearch if Authentication Enabled is checked.</details> | Liferay 7.3+ |
@@ -48,7 +48,7 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | Connection ID | <details><summary>`connectionId=""`</summary>Set a unique ID for the connection. If active, this connection becomes available to select in the Elasticsearch 7 configuration's Remote Cluster Connection ID property.</details> | Liferay 7.3+ |
 | | <a href="#rest-client-settings" id="rest-client-settings">REST CLIENT SETTINGS</a> |
 | Network Host Addresses | <details><summary>`networkHostAddresses="[http://localhost:9200]"`</summary>Set the remote HTTP hosts to connect to. This is required in Liferay 7.3 as it configures the REST client connection.</details> | Liferay 7.3+ |
-| REST Client Logger Level | <details><summary>`RESTClientLoggerLevel="ERROR"`</summary></details> | Liferay 7.3+ |
+| REST Client Logger Level | <details><summary>`RESTClientLoggerLevel="ERROR"`</summary>Set the logging level for the Elasticsearch REST client.</details> | Liferay 7.3+ |
 | | <a href="#transport-client-settings" id="transport-client-settings">TRANSPORT CLIENT SETTINGS</a> |
 | Cluster Name | <details><summary>`clusterName="LiferayElasticsearchCluster"`</summary>The cluster name is only needed for the Transport Client in Liferay 7.2. Set a String value to declare the cluster to integrate with. In Liferay 7.3+, where the connection is managed through the REST client, this property is only used for naming the embedded cluster when in development mode.</details> | Liferay 7.2-<br />On 7.3+, applies to development mode |
 | Transport Addresses | <details><summary>`transportAddresses=["localhost:9300"]`</summary>Set the String values for the addresses of the remote Elasticsearch nodes to connect to. This value is required when Operation Mode is set to remote (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information). Specify as many or few nodes as you see fit.</details> | Liferay 7.2- |
@@ -66,6 +66,7 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | Network Host | <details><summary>`networkHost=""`</summary>Set this String value to instruct the node to bind to this hostname or IP address and publish (advertise) this host to other nodes in the cluster. This is a shortcut which sets the bind host and the publish host at the same time (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#common-network-settings) for more information).</details> | Liferay 7.2+  |
 | Network Bind Host | <details><summary>`networkBindHost=""`</summary>Set the String value of the network interface(s) a node should bind to in order to listen for incoming requests (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#advanced-network-settings) for more information).</details> | Liferay 7.2+ |
 | Network Publish Host | <details><summary>`networkPublishHost=""`</summary>Set the String value of a single interface that the node advertises to other nodes in the cluster, so that those nodes can connect to it (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#advanced-network-settings) for more information).</details> | Liferay 7.2+ |
+| | <a href="#sidecar-settings" id="sidecar-settings">SIDECAR SETTINGS</a> | 
 | Node Name | <details><summary>`nodeName=`</summary>Name the embedded Elasticsearch server's node. A remote Elasticsearch server's node name is configured in its `elasticsearch.yml`.</details> | Liferay 7.3+ |
 | Sidecar Debug | <details><summary>`sidecarDebug=B"false"`</summary>Set this to true to enable debug mode for the sidecar process.</details> | Liferay 7.3+ |
 | Sidecar Debug Settings | <details><summary>`sidecarDebugSettings="-agentlib:jdwp=transport=dt_socket,address=8001,server=y,suspend=y,quiet=y"`</summary>Set the JVM options used to debug the sidecar process.</details> | Liferay 7.3+ |
@@ -87,175 +88,6 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | Proxy Password | <details><summary>`proxyPassword=""`</summary>Set the password for connecting to the proxy.</details> | Liferay DXP 7.3 FP1+/SP1+ and Liferay Portal CE GA7+ |
 | | <a href="#deprecated-settings" id="deprecated-settings">DEPRECATED</a> |
 | Operation Mode | <details><summary>`operationMode="EMBEDDED"`</summary>There are two operation modes you can choose from: EMBEDDED or REMOTE. Set to REMOTE to connect to a remote standalone Elasticsearch cluster. Set to EMBEDDED to start Liferay with an internal Elasticsearch instance. EMBEDDED operation mode is unsupported for production environments and can be considered a "development mode" feature.</details> | Deprecated as of Liferay 7.3, replaced with _Production Mode Enabled_  |
-| Embedded HTTP Port | <details><summary>`embeddedHttpPort="9201"`</summary></details> | Deprecated as of Liferay 7.3.x |
-| Http Enabled | <details><summary>`httpEnabled=B"true"`</summary></details> | Deprecated as of Liferay 7.1.x<br />Deprecated Elasticsearch 6.3.x |
+| Embedded HTTP Port | <details><summary>`embeddedHttpPort="9201"`</summary>This configuration only applies to EMBEDDED mode. Set the HTTP port of the embedded Elasticsearch node that is created when Operation Mode is set to EMBEDDED.</details> | Deprecated as of Liferay 7.3.x |
+| Http Enabled | <details><summary>`httpEnabled=B"true"`</summary>If this is checked, the HTTP layer is enabled. If unchecked, the HTTP layer is disabled on nodes which are not meant to serve REST requests directly.</details> | Deprecated as of Liferay 7.1.x<br />Deprecated Elasticsearch 6.3.x |
 
-
-<!-- 
-## Property Descriptions
-
-The configuration settings are categorized by where they appear: those unique to the Elasticsearch 7 entry, those unique to the Elasticsearch connections entry, and those common to both. The Elasticsearch 7 and Elasticsearch Connections entries are found under System Settings &rarr; Search.
-
-### Properties Unique to the Elasticsearch 7 Configuration
-
-Many of the connection settings are only found in the Elasticsearch 7 configuration entry. They can be categorized according to 
-
-- production mode settings for defining the connection mode and declaring which connection to use (if you have multiple connections defined in an Elasticsearch Connections entry)
-- development mode settings to configure the embedded or sidecar Elasticsearch (e.g., naming the server node)
-- Settings that are not specific to the connection, but that configure Liferay's search infrastructure or behavior (e.g., index name prefixes)
-
-#### Defining the Remote Connection
-
-**Operation Mode, `operationMode="EMBEDDED"`** \
-There are two operation modes you can choose from: EMBEDDED or REMOTE. Set to REMOTE to connect to a remote standalone Elasticsearch cluster. Set to EMBEDDED to start Liferay with an internal Elasticsearch instance. EMBEDDED operation mode is unsupported for production environments and can be considered a "development mode" feature.
-
-**Remote Cluster Connection ID, `remoteClusterConnectionId`** \
-Choose the connection ID for a connection to the remote Elasticsearch cluster. The available connections are defined in the Elasticsearch Connections System Settings entry. If this value is not set then the connection configurations in the Elasticsearch 7 entry are used for the remote cluster connection.
-
-#### Configuring Liferay's Search Infrastructure
-
-**Index Name Prefix, `indexNamePrefix="liferay-"`** \
-Set a String value to use as the prefix for the search index name. The default value should not be changed under normal conditions. If you change it, you must also perform a *re-index all* operation for the portal and then manually delete the old index using the Elasticsearch administration console.
-
-**Additional Index Configurations, `additionalIndexConfigurations=`** \
-Set the String values for custom settings for the Liferay index, in JSON or YML format (refer to the Elasticsearch Create Index API for more information).  See: Adding Settings to the Liferay Elasticsearch Connector
-
-**Additional Type Mappings, `additionalTypeMappings=`** \
-Set the String values for custom mappings for the `LiferayDocumentType`, in JSON format (refer to the Elasticsearch Put Mapping API for more information) See: Adding Settings to the Liferay Elasticsearch Connector
-
-**Override Type Mappings, `overrideTypeMappings=`** \
-Settings here override Liferay's default type mappings. This is an advanced feature that should be used only if strictly necessary. If you set this value, the default mappings used to define the Liferay Document Type in Liferay source code (for example, `liferay-type-mappings.json`) are ignored entirely, so include the whole mappings definition in this property, not just the segment you're modifying.
-
-[7.2-] **Transport Addresses, `transportAddresses="localhost:9300"`** \
-Set the String values for the addresses of the remote Elasticsearch nodes to connect to. This value is required when Operation Mode is set to remote (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information). Specify as many or few nodes as you see fit.
-
-[7.2-] **Client Transport Sniff, `clientTransportSniff="true"`** \
-Set this boolean to true to enable cluster sniffing and dynamically discover available data nodes in the cluster (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).
-
-[7.2-] **Client Transport Ignore Cluster Name, `clientTransportIgnoreClusterName="false"`** \
-Set this boolean to true to ignore cluster name validation of connected nodes (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).
-
-[7.2-] **Client Transport Ping Timeout, `clientTransportPingTimeout=`** \
-Set the time (in seconds) the client node waits for a ping response from a node. If unset, the default Elasticsearch `client.transport.ping_timeout` is used.
-
-[7.2-] **Client Transport Nodes Sampler Interval, `clientTransportNodesSamplerInterval=`** \
-Set this String value to instruct the client node on how often to sample / ping the nodes listed and connected (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).
-
-**Log Exceptions Only, `logExceptionsOnly="true"`** \
-A boolean setting that, when set to true, only logs exceptions from Elasticsearch, and does not re-throw them.
-
-#### Configuring the Development Mode Server
-
-**Cluster Name, `clusterName="LiferayElasticsearchCluster"`** \
-The cluster name is only needed for the Transport Client in Liferay 7.2. Set a String value to declare the cluster to integrate with. In Liferay 7.3+, where the connection is managed through the REST client, this property is only used for naming the embedded cluster when in development mode.
-
-**Node Name, `nodeName=`** \
-Name the embedded Elasticsearch server's node. A remote Elasticsearch server's node name is configured in its `elasticsearch.yml`.
-
-**Additional Configurations, `additionalConfigurations=`** \
-Set the String values for custom settings for embedded Elasticsearch, in YML format. See: Adding Settings to the Liferay Elasticsearch Connector
-
-**Bootstrap Mlock All, `bootstrapMlockAll="false"`**
-A boolean setting that, when set to `true`, tries to lock the process address space into RAM, preventing any Elasticsearch memory from being swapped out (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/setup-configuration-memory.html#bootstrap-memory_lock)) for more information)
-
-**Http CORS Allow Origin, `httpCORSAllowOrigin="/https?:\\/\\/localhost(:[0-9]+)?/"** \
-Set the String origins to allow when HTTP CORS is enabled (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).
-
-**Http CORS Configurations, `httpCORSConfigurations=** \
-Set the String values for custom settings for HTTP CORS, in YML format (`elasticsearch.yml`) (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).
-
-**Http CORS Enabled, `httpCORSEnabled="true"** \
-Set this boolean to false to disable cross-origin resource sharing. When set to `false`, a browser on another origin cannot make requests to Elasticsearch. Web front end tools like Elasticsearch Head may be unable to connect (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).
-
-**Network Host, `networkHost=""** \
-Set this String value to instruct the node to bind to this hostname or IP address and publish (advertise) this host to other nodes in the cluster. This is a shortcut which sets the bind host and the publish host at the same time (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#common-network-settings) for more information).
-
-**Network Bind Host, `networkBindHost=""** \
-Set the String value of the network interface(s) a node should bind to in order to listen for incoming requests (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#advanced-network-settings) for more information).
-
-**Network Publish Host, `networkPublishHost=""** \
-Set the String value of a single interface that the node advertises to other nodes in the cluster, so that those nodes can connect to it (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#advanced-network-settings) for more information).
-
-**Sidecar Debug, `sidecarDebug="false"** \
-Set this to true to enable debug mode for the sidecar process.
-
-**Sidecar Debug Settings, `sidecarDebugSettings="-agentlib:jdwp=transport=dt_socket,address=8001,server=y,suspend=y,quiet=y"** \
-Set the JVM options used to debug the sidecar process.
-
-**Sidecar Heartbeat Interval, `sidecarHeartbeatInterval="10000"** \
-Set the heartbeat interval in milliseconds used to detect the health of the sidecar process.
-
-**Sidecar Home, `sidecarHome="elasticsearch7"** \
-Set the path of the sidecar base folder used to start the sidecar process.
-
-**Sidecar HTTP Port, `sidecarHttpPort="9200"** \
-This configuration only applies to Liferay 7.3 with the sidecar Elasticsearch. Set the HTTP port range of the sidecar Elasticsearch node. Set to AUTO to automatically find a port in the 9201-9300 range. If unset, the value of Embedded HTTP port (`9201` by default) is used.
-
-**Sidecar JVM Options, `sidecarJVMOptions="-Xms1g|-Xmx1g|-XX:+AlwaysPreTouch"** \
-Set the JVM options used by the sidecar process.
-
-**Sidecar Shutdown Timeout, `sidecarShutdownTimeout="10000"** \
-Set the time in milliseconds to wait before the sidecar process is forcibly shut down.
-
-**Transport Tcp Port, `transportTcpPort=""** \
-Set the String value for the port to bind for communication between nodes.  Accepts a single value or a range (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-transport.html#_tcp_transport) for more information).
-
-**Zen Discovery Unicast Hosts Port, `discoveryZenPingUnicastHostsPort="9300-9400"** \
-Set a String value for the range of ports to use when building the value for `discovery.zen.ping.unicast.hosts`. Multiple Elasticsearch nodes on a range of ports can act as gossip routers at the same computer (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-discovery-hosts-providers.html) for more information).
-
-### Properties Unique to the Elasticsearch Connections Configuration
-
-**Active, `active="false"`** \
-Activate or deactivate the connection as needed. Do not deactivate a connection if it's selected in the Elasticsearch 7 configuration's Remote Cluster Connection ID setting.
-
-**Connection ID, `connectionId=`** \
-Set a unique ID for the connection. If active, this connection becomes available to select in the Elasticsearch 7 configuration's Remote Cluster Connection ID property.
-
-### Properties Shared Between the Elasticsearch 7 and Elasticsearch Connections Configurations
-
-Configuration that would be unique depending on the defined connection are available from both the Elasticsearch 7 and the Elasticsearch Connections configurations.
-
-**Network Host Addresses, `networkHostAddresses="http://localhost:9200"** \
-Set the remote HTTP hosts to connect to. This is required in Liferay 7.3 as it configures the REST client connection.
-
-**Authentication Enabled, `authenticationEnabled="false"** \
-Enable or disable authentication to Elasticsearch with a user name and password.
-
-**Username, `username="elastic"** \
-Set the user name for authenticating to Elasticsearch if Authentication Enabled is checked.
-
-**Password, `password=** \
-Set the password for authenticating to Elasticsearch if Authentication Enabled is checked.
-
-**Http SSL Enabled, `httpSSLEnabled="false"** \
-Enable or disable TLS/SSL.
-
-**Truststore Type, `truststoreType="pkcs12"** \
-Set the truststore type if HTTP SSL Enabled is checked.
-
-**Truststore Path, `truststorePath="/path/to/localhost.p12"** \
-Set the path to the truststore file if HTTP SSL Enabled is checked.
-
-**Truststore Password, `truststorePassword=** \
-Set the password to the truststore if HTTP SSL Enabled is checked.
-
-**Proxy Host, `proxyHost=`** \
-Set the proxy host for the client connection.
-
-**Proxy Port, `proxyPort="0"`** \
-Set the proxy port for the client connection.
-
-**Proxy Username, `proxyUserName=`** \
-Set the proxy user name for a proxy connection.
-
-**Proxy Password, `proxyPassword=`** \
-Set the password for connecting to the proxy.
-
-## Related Topics
-
-- [What's New in Search for 7.3?](../../getting-started/whats-new-in-search-for-73.md)
-- [Securing Elasticsearch](securing-elasticsearch.md)
-- [Connecting to Elasticsearch](connecting-to-elasticsearch.md)
-- [Liferay DXP Elasticsearch Connectors: Technical Data Sheet (KB Reference)](https://help.liferay.com/hc/en-us/articles/360046478452)
-- [Understanding Liferay DXP's compatibility with Elasticsearch (KB Reference)](https://help.liferay.com/hc/en-us/articles/360051492032)
-    -->

--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
@@ -1,14 +1,46 @@
-# Elasticsearch Connection Settings
+# Elasticsearch Connector Reference
 
-> The configuration information here applies to Liferay's Elasticsearch connector as of Liferay DXP 7.3.10 SP1. Information for Liferay 7.2 is provided where appropriate.
+> The configuration information here applies to the latest available (bundled or through Marketplace) version of the Elasticsearch 6 and Elasticsearch 7 connectors for Liferay Portal 7.3 CE and for Liferay DXP 7.2 and 7.3. Appropriate information about the exact GA/Service Pack/Fix Pack and Marketplace versions are provided where needed.
 
-Elasticsearch is Liferay's default search engine. The connection to Elasticsearch is primarily defined in the _Elasticsearch 7_ configuration entry in System Settings (or via [corresponding configuration file](#elasticsearch-connection-configuration-entries)). Liferay 7.3 introduced the possibility to define multiple connections to Elasticsearch, through the [factory configuration](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-factory-configuration.md) _Elasticsearch Connections_ configuration. Both configuration entries are configurable through [System Settings](../../../system-administration/configuring-liferay/system-settings.md) or an [OSGi configuration file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md). 
+## Introduction
+Elasticsearch is Liferay's default search engine. Each Liferay Portal CE and Liferay DXP version is **bundled** with a connector to Elasticsearch that is compatible with a specific Elasticsearch major version:
+
+    Liferay DXP 7.2 & Liferay Portal 7.2 CE => Elasticsearch 6
+    Liferay DXP 7.3 & Liferay Portal 7.3 CE => Elasticsearch 7
+    
+To add support for newer major Elasticsearch versions for released DXP versions, Liferay releases **new connectors through Marketplace**. These connectors can be used as drop-in replacements for the out-of-the-box (bundled) connectors:
+
+    Liferay DXP 7.2 => Liferay Connector to Elasticsearch 7
+
+Most of the time, the last released connector on Marketplace for one DXP version becomes the out-of-the-box bundled connector in the next DXP version. For example, DXP 7.3 comes with the Liferay Connector to Elasticsearch 7 bundled, and this connector is available for Liferay 7.2 on Marketplace.
+
+## Configuration Overview
+
+The connection to Elasticsearch is primarily defined in the _Elasticsearch 6/7_ configuration entry in System Settings (or via [corresponding configuration file](#elasticsearch-connection-configuration-entries)). Liferay 7.3 introduced the possibility to define multiple connections to Elasticsearch, through the [factory configuration](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-factory-configuration.md) _Elasticsearch Connections_ configuration. Both configuration entries are configurable through [System Settings](../../../system-administration/configuring-liferay/system-settings.md) or an [OSGi configuration file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md) (recommended: use config files). 
+
+## Configuration Files and System Settings Entries
+
+| Connecting Servers | <div style="width:380px">System Settings Entry/Configuration File</div> |
+| --------------- | -------------------------------------- | 
+| Liferay 7.2.x<br />Elasticsearch 6.x  | Elasticsearch 6<br />`com.liferay.portal.search.elasticsearch6.configuration.ElasticsearchConfiguration.config` |
+| Liferay 7.2.x<br />Elasticsearch 7.x  | Elasticsearch 7<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config` |
+| Liferay 7.3.x<br />Elasticsearch 7.x  | Elasticsearch 7<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config`<br /><br />Elasticsearch Connections (factory)<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConnectionConfiguration-[key].config` |
+
+In Liferay 7.3 and beyond, there's an additional connection configuration entry, Elasticsearch Connections. You can use this to define any connection to Elasticsearch, but if you are only configuring one connection you can still use the main Elasticsearch 7 configuration entry. If using multiple connections in 7.3+, define connections with files named accordingly:
+
+```
+com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConnectionConfiguration-[connectionId].config
+```
+
+If configuring security on Elasticsearch 6, a separate Liferay configuration (as well as a LES subscription) is required. See [Securing Elasticsearch](securing-elasticsearch.md) for more information.
+
+Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-detects the configurations and writes them to the database.
+
+## System Settings & Config File Properties
 
 [**Click here to jump to the property descriptions.**](#property-descriptions)
 
-**Configuration Properties Overview:**
-
-| System Settings Field | <div style="width:280px">Configuration File Field**<br />(default value) | Liferay/Elasticsearch Version Details |
+| System Settings UI Field Name | <div style="width:280px">Configuration File Property Name & Default Value | Liferay/Elasticsearch Version Details |
 | ----------------------------------- | -------------------------------------------------- | ------------------------------------- | 
 | | GENERAL CONNECTION SETTINGS |
 | Track Total Hits | `trackTotalHits="true"` | Liferay 7.2+<br />Elasticsearch 7 |
@@ -72,28 +104,6 @@ Elasticsearch is Liferay's default search engine. The connection to Elasticsearc
 | Operation Mode | `operationMode="EMBEDDED"` | Deprecated in Liferay 7.3.x |
 | Embedded HTTP Port | `embeddedHttpPort="9201"` | Deprecated in Liferay 7.3.x |
 | Http Enabled | `httpEnabled="true"` | Deprecated in Liferay 7.1.x<br />Deprecated Elasticsearch 6.3.x |
-
-## Elasticsearch Connection Configuration Entries
-
-In Liferay 7.3 and beyond (or on earlier versions with [LES Cross-Cluster Replication](../../liferay-enterprise-search/cross-cluster-replication/cross-cluster-replication.md)), there's an additional connection configuration entry, Elasticsearch Connections. You can use this to define any connection to Elasticsearch, but if you are only configuring one connection you can still use the Elasticsearch 7 configuration entry.
-
-**Configuration Files and System Settings Entries:**
-
-| Connecting Servers | <div style="width:380px">System Settings Entry/Configuration File</div> |
-| --------------- | -------------------------------------- | 
-| Liferay 7.2.x<br />Elasticsearch 6.x  | Elasticsearch 6<br />`com.liferay.portal.search.elasticsearch6.configuration.ElasticsearchConfiguration.config` |
-| Liferay 7.2.x<br />Elasticsearch 7.x  | Elasticsearch 7<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config` |
-| Liferay 7.3.x<br />Elasticsearch 7.x  | Elasticsearch 7<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config`<br /><br />Elasticsearch Connections (factory)<br />`com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConnectionConfiguration-[key].config` |
-
-If using multiple connections, define connections with files named accordingly:
-
-```
-com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConnectionConfiguration-[key].config
-```
-
-If configuring security on Elasticsearch 6, a separate Liferay configuration (as well as a LES subscription) is required. See [Securing Elasticsearch](securing-elasticsearch.md) for more information.
-
-Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-detects the configurations and writes them to the database.
 
 ## Property Descriptions
 

--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
@@ -40,41 +40,40 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 
 [**Click here to jump to the property descriptions.**](#property-descriptions)
 
-| System Settings UI Field Name | <div style="width:280px">Configuration File Property Name & Default Value | Liferay/Elasticsearch Version Details |
-| ----------------------------------- | -------------------------------------------------- | ------------------------------------- | 
+| System Settings UI Field Name | <div style="width:280px">Configuration File Property Name, Default Value & Description | Available in |
+| ----------------------------- | -------------------------------------------------------------------------------------- | ------------ | 
 | | GENERAL CONNECTION SETTINGS |
-| Track Total Hits | `trackTotalHits="true"` | Liferay 7.2+<br />Elasticsearch 7 |
-| Production Mode Enabled | `productionModeEnabled="false"` | Liferay 7.3+ |
+| Track Total Hits | `trackTotalHits=B"true"`<details><summary>Description</summary>If enabled, hits are accurately counted when there are more than 10,000 results for a search. Leaving this enabled may have an impact on performance when there is a large number of hits for a search.</details> | Liferay 7.2+<br />(Connector to Elasticsearch 7) |
+| Production Mode Enabled | `productionModeEnabled=B"false"` | Liferay 7.3+ |
 | Index Name Prefix | `indexNamePrefix="liferay-"` | Liferay 7.2+ |
-| 7.3.x&rarr;Number of Company and System Index Replicas<br />7.2.x&rarr;Index Number of Replicas | `indexNumberOfReplicas=""` | Liferay 7.2+ |
-| 7.3.x&rarr;Number of Company and System Index Shards<br />7.2.x&rarr;Index Number of Shards | `indexNumberOfShards=""` | Liferay 7.2+ |
+| 7.3.x&rarr;Number of Company and System Index Replicas<br />7.2.x&rarr;Index Number of Replicas | `indexNumberOfReplicas="0-all"`<details><summary>Description</summary>Set the number of replicas for each Liferay company and system index. If unset, no replicas are used. Changing this value requires a full re-index. The default value is defined in a file called "index-settings-defaults.json" shipped with the connector.</details> | Liferay 7.2+ |
+| 7.3.x&rarr;Number of Company and System Index Shards<br />7.2.x&rarr;Index Number of Shards | `indexNumberOfShards="1"`<details><summary>Description</summary>Set the number of shards to use when a Liferay company and system index is created. If unset, a single shard will be used. Changing this value requires a full re-index. The default value is defined in a file called "index-settings-defaults.json" shipped with the connector.</details> | Liferay 7.2+ |
 | Log Exceptions Only | `logExceptionsOnly="true"` | Liferay 7.2+ |
 | Retry On Conflict | `retryOnConflict="5"` | Liferay 7.2- |
 | | *SECURITY SETTINGS* |
 | Authentication Enabled | `authenticationEnabled="false"` | Liferay 7.3+ |
 | Username | `username="elastic"` | Liferay 7.3+ |
-| Password | `password=` | Liferay 7.3+ |
+| Password | `password=""` | Liferay 7.3+ |
 | Http SSL Enabled | `httpSSLEnabled="false"` | Liferay 7.3+ |
 | Truststore Type | `truststoreType="pkcs12"` | Liferay 7.3+ |
 | Truststore Path | `truststorePath="/path/to/localhost.p12"` | Liferay 7.3+ |
-| Truststore Password | `truststorePassword=` | Liferay 7.3+ |
+| Truststore Password | `truststorePassword=""` | Liferay 7.3+ |
 | | *ELASTICSEARCH CONNECTIONS SETTINGS* |
-| Active | `active="false"` | Liferay 7.3+ |
-| Connection ID | `connectionId=` | Liferay 7.3+ |
+| Active | `active=B"false"` | Liferay 7.3+ |
+| Connection ID | `connectionId=""` | Liferay 7.3+ |
 | | *CONNECTION DECLARATION SETTINGS* |
 | Remote Cluster Connection ID | `remoteClusterConnectionId=` | Liferay 7.3+ if using the `ElasticsearchConnectionConfiguration` |
 | | *REST CLIENT SETTINGS* |
-| Network Host Addresses | `networkHostAddresses="http://localhost:9200"` | Liferay 7.3+ |
+| Network Host Addresses | `networkHostAddresses="[http://localhost:9200]"` | Liferay 7.3+ |
 | REST Client Logger Level | `RESTClientLoggerLevel="ERROR"` | Liferay 7.3+ |
 | | *TRANSPORT CLIENT SETTINGS* |
 | Cluster Name | `clusterName="LiferayElasticsearchCluster"` | Liferay 7.2-<br />On 7.3+, applies to development mode |
-| Transport Addresses | `transportAddresses="localhost:9300"` | Liferay 7.2- |
-| Client Transport Sniff | `clientTransportSniff="true"` | Liferay 7.2- |
-| Client Transport Ignore Cluster Name | `clientTransportIgnoreClusterName="false"` | Liferay 7.2- |
-| Client Transport Ping Timeout | `clientTransportPingTimeout=` | Liferay 7.2- |
-| Client Transport Nodes Sampler Interval | `clientTransportNodesSamplerInterval=` | Liferay 7.2- |
+| Transport Addresses | `transportAddresses=["localhost:9300"]` | Liferay 7.2- |
+| Client Transport Sniff | `clientTransportSniff=B"true"` | Liferay 7.2- |
+| Client Transport Ignore Cluster Name | `clientTransportIgnoreClusterName=B"false"` | Liferay 7.2- |
+| Client Transport Ping Timeout | `clientTransportPingTimeout=""` | Liferay 7.2- |
+| Client Transport Nodes Sampler Interval | `clientTransportNodesSamplerInterval=""` | Liferay 7.2- |
 | | *DEVELOPMENT MODE SETTINGS* | 
-| Additional Configurations | `additionalConfigurations=` | Liferay 7.2+ |
 | Bootstrap Mlock All | `bootstrapMlockAll="false"` | Liferay 7.2+ |
 | Http CORS Allow Origin | `httpCORSAllowOrigin="/https?:\\/\\/localhost(:[0-9]+)?/"` | Liferay 7.2+ |
 | Http CORS Configurations | `httpCORSConfigurations=` | Liferay 7.2+ |
@@ -93,15 +92,16 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | Transport Tcp Port | `transportTcpPort=""` | Liferay 7.2+ |
 | Zen Discovery Unicast Hosts Port | `discoveryZenPingUnicastHostsPort="9300-9400"` | Liferay 7.2+ |
 | | ADVANCED CONFIGURATION |
-| Additional Index Configurations | `additionalIndexConfigurations=` | Liferay 7.2+ |
-| Additional Type Mappings | `additionalTypeMappings=` | Liferay 7.2+ |
-| Override Type Mappings | `overrideTypeMappings=` | Liferay 7.2+ |
-| Proxy Host | `proxyHost=` | Liferay 7.3+ |
-| Proxy Port | `proxyPort="0"` | Liferay 7.3+ |
-| Proxy Username | `proxyUserName=` | Liferay 7.3+ |
-| Proxy Password | `proxyPassword=` | Liferay 7.3+ |
+| Additional Configurations | `additionalConfigurations=""` | Liferay 7.2+ |
+| Additional Index Configurations | `additionalIndexConfigurations=""` | Liferay 7.2+ |
+| Additional Type Mappings | `additionalTypeMappings=""` | Liferay 7.2+ |
+| Override Type Mappings | `overrideTypeMappings=""` | Liferay 7.2+ |
+| Proxy Host | `proxyHost=""` | Liferay DXP 7.3 FP1+/SP1+ and Liferay Portal CE GA7+ |
+| Proxy Port | `proxyPort="0"` | Liferay DXP 7.3 FP1+/SP1+ and Liferay Portal CE GA7+ |
+| Proxy Username | `proxyUserName=""` | Liferay DXP 7.3 FP1+/SP1+ and Liferay Portal CE GA7+ |
+| Proxy Password | `proxyPassword=""` | Liferay DXP 7.3 FP1+/SP1+ and Liferay Portal CE GA7+ |
 | | *DEPRECATED* |
-| Operation Mode | `operationMode="EMBEDDED"` | Deprecated in Liferay 7.3.x |
+| Operation Mode | `operationMode="EMBEDDED"` | Deprecated in Liferay 7.3, replaced with _Production Mode Enabled_  |
 | Embedded HTTP Port | `embeddedHttpPort="9201"` | Deprecated in Liferay 7.3.x |
 | Http Enabled | `httpEnabled="true"` | Deprecated in Liferay 7.1.x<br />Deprecated Elasticsearch 6.3.x |
 

--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
@@ -87,7 +87,7 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | Sidecar Heartbeat Interval | `sidecarHeartbeatInterval="10000"` | Liferay 7.3+ |
 | Sidecar Home | `sidecarHome="elasticsearch7"` | Liferay 7.3+ |
 | Sidecar HTTP Port | `sidecarHttpPort="9200"` | Liferay 7.3+ |
-| Sidecar JVM Options | `sidecarJVMOptions="-Xms1g|-Xmx1g|-XX:+AlwaysPreTouch"` | Liferay 7.3+ |
+| Sidecar JVM Options | `sidecarJVMOptions="-Xms1g\|-Xmx1g\|-XX:+AlwaysPreTouch"` | Liferay 7.3+ |
 | Sidecar Shutdown Timeout | `sidecarShutdownTimeout="10000"` | Liferay 7.3+ |
 | Transport Tcp Port | `transportTcpPort=""` | Liferay 7.2+ |
 | Zen Discovery Unicast Hosts Port | `discoveryZenPingUnicastHostsPort="9300-9400"` | Liferay 7.2+ |

--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
@@ -27,7 +27,6 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | System Settings Field Name | <div style="width:290px">Configuration File Syntax and Default Value<br />Description (Click to Expand) | Availability |
 | ----------------------------- | ------------------------------------------------------------------------------ | ------------ | 
 | | <a href="#general-connection-settings" id="general-connection-settings">GENERAL CONNECTION SETTINGS</a> |
-| Track Total Hits | <details><summary><code>trackTotalHits=B"true"</code></summary>If enabled, hits are accurately counted when there are more than 10,000 results for a search. Leaving this enabled may have an impact on performance when there is a large number of hits for a search.</details> | Liferay 7.2+<br />(Connector to Elasticsearch 7) |
 | Track Total Hits | <details><summary>`trackTotalHits=B"true"`</summary>If enabled, hits are accurately counted when there are more than 10,000 results for a search. Leaving this enabled may have an impact on performance when there is a large number of hits for a search.</details> | Liferay 7.2+<br />(Connector to Elasticsearch 7) |
 | Production Mode Enabled | <details><summary>`productionModeEnabled=B"false"`</summary>Enable production mode. In Liferay 7.3, <code>productionModeEnabled</code> replaces the deprecated setting <code>operationMode</code>. If this is checked, production mode is enabled and the Operation Mode configuration is ignored. Enabling production mode requires connecting to a remote standalone Elasticsearch cluster. If left disabled, the Operation Mode configuration is used.</details> | Liferay 7.3+ |
 | Index Name Prefix | <details><summary>`indexNamePrefix="liferay-"`</summary>Set a String value to use as the prefix for the search index name. The default value should not be changed under normal conditions. If you change it, you must also perform a *re-index all* operation for the portal and then manually delete the old index using the Elasticsearch administration console.</details> | Liferay 7.2+ |
@@ -91,3 +90,9 @@ Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-
 | Embedded HTTP Port | <details><summary>`embeddedHttpPort="9201"`</summary>This configuration only applies to EMBEDDED mode. Set the HTTP port of the embedded Elasticsearch node that is created when Operation Mode is set to EMBEDDED.</details> | Deprecated as of Liferay 7.3.x |
 | Http Enabled | <details><summary>`httpEnabled=B"true"`</summary>If this is checked, the HTTP layer is enabled. If unchecked, the HTTP layer is disabled on nodes which are not meant to serve REST requests directly.</details> | Deprecated as of Liferay 7.1.x<br />Deprecated Elasticsearch 6.3.x |
 
+## Related Topics
+- [What's New in Search for 7.3?](../../getting-started/whats-new-in-search-for-73.md)
+- [Securing Elasticsearch](securing-elasticsearch.md)
+- [Connecting to Elasticsearch](connecting-to-elasticsearch.md)
+- [Liferay DXP Elasticsearch Connectors: Technical Data Sheet (KB Reference)](https://help.liferay.com/hc/en-us/articles/360046478452)
+- [Understanding Liferay DXP's compatibility with Elasticsearch (KB Reference)](https://help.liferay.com/hc/en-us/articles/360051492032)

--- a/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
+++ b/docs/dxp/latest/en/using-search/installing-and-upgrading-a-search-engine/elasticsearch/elasticsearch-connector-settings.md
@@ -2,11 +2,9 @@
 
 > The configuration information here applies to the latest available (bundled or through Marketplace) version of the Elasticsearch 6 and Elasticsearch 7 connectors for Liferay Portal 7.3 & 7.4 CE and for Liferay DXP 7.2 & 7.3. Appropriate information about the exact GA/Service Pack/Fix Pack and Marketplace versions are provided where needed.
 
-## Overview
+The connection to Elasticsearch is primarily defined in the _Elasticsearch 6/7_ configuration entry in System Settings (or via [corresponding configuration file](#configuration-files-and-system-settings-entries)). Liferay 7.3 introduced the possibility to define multiple connections to Elasticsearch, through the [factory configuration](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-factory-configuration.md) _Elasticsearch Connections_. Both configuration entries are configurable through [System Settings](../../../system-administration/configuring-liferay/system-settings.md) or an [OSGi configuration file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md). Configuration files are the recommended approach for production environments.
 
-The connection to Elasticsearch is primarily defined in the _Elasticsearch 6/7_ configuration entry in System Settings (or via [corresponding configuration file](#elasticsearch-connection-configuration-entries)). Liferay 7.3 introduced the possibility to define multiple connections to Elasticsearch, through the [factory configuration](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-factory-configuration.md) _Elasticsearch Connections_ configuration. Both configuration entries are configurable through [System Settings](../../../system-administration/configuring-liferay/system-settings.md) or an [OSGi configuration file](../../../system-administration/configuring-liferay/configuration-files-and-factories/using-configuration-files.md) (recommended: use config files). 
-
-## System Settings Entries & Config Files
+## Configuration Files and System Settings Entries
 
 | Connecting Servers | <div style="width:380px">System Settings Entry/Configuration File</div> |
 | --------------- | -------------------------------------- | 
@@ -24,73 +22,76 @@ If configuring security on Elasticsearch 6, a separate Liferay configuration (as
 
 Deploy configuration files to `[Liferay_Home]/osgi/configs` and a listener auto-detects the configurations and writes them to the database.
 
-## System Settings & Config File Properties
+## Configuration Properties
 
-| System Settings UI Field Name | <div style="width:280px">Configuration File Usage, Default Value & Description | Available in |
+| System Settings Field Name | <div style="width:290px">Configuration File Syntax and Default Value<br />Description (Click to Expand) | Availability |
 | ----------------------------- | ------------------------------------------------------------------------------ | ------------ | 
 | | <a href="#general-connection-settings" id="general-connection-settings">GENERAL CONNECTION SETTINGS</a> |
-| Track Total Hits | `trackTotalHits=B"true"`<details><summary>Description</summary>If enabled, hits are accurately counted when there are more than 10,000 results for a search. Leaving this enabled may have an impact on performance when there is a large number of hits for a search.</details> | Liferay 7.2+<br />(Connector to Elasticsearch 7) |
-  | Production Mode Enabled | `productionModeEnabled=B"false"`<details><summary>Description</summary>Enable production mode. In Liferay 7.3, <code>productionModeEnabled</code> replaces the deprecated setting <code>operationMode</code>. If this is checked, production mode is enabled and the Operation Mode configuration is ignored. Enabling production mode requires connecting to a remote standalone Elasticsearch cluster. If left disabled, the Operation Mode configuration is used.</details> | Liferay 7.3+ |
-| Index Name Prefix | `indexNamePrefix="liferay-"` | Liferay 7.2+ |
-| 7.3.x&rarr;Number of Company and System Index Replicas<br />7.2.x&rarr;Index Number of Replicas | `indexNumberOfReplicas="0-all"`<details><summary>Description</summary>Set the number of replicas for each Liferay company and system index. If unset, no replicas are used. Changing this value requires a full re-index. The default value is defined in a file called "index-settings-defaults.json" shipped with the connector.</details> | Liferay 7.2+ |
-| 7.3.x&rarr;Number of Company and System Index Shards<br />7.2.x&rarr;Index Number of Shards | `indexNumberOfShards="1"`<details><summary>Description</summary>Set the number of shards to use when a Liferay company and system index is created. If unset, a single shard will be used. Changing this value requires a full re-index. The default value is defined in a file called "index-settings-defaults.json" shipped with the connector.</details> | Liferay 7.2+ |
-| Log Exceptions Only | `logExceptionsOnly=B"true"` | Liferay 7.2+ |
-| Retry On Conflict | `retryOnConflict="5"` | Liferay 7.2- |
+| Track Total Hits | <details><summary><code>trackTotalHits=B"true"</code></summary>If enabled, hits are accurately counted when there are more than 10,000 results for a search. Leaving this enabled may have an impact on performance when there is a large number of hits for a search.</details> | Liferay 7.2+<br />(Connector to Elasticsearch 7) |
+| Track Total Hits | <details><summary>`trackTotalHits=B"true"`</summary>If enabled, hits are accurately counted when there are more than 10,000 results for a search. Leaving this enabled may have an impact on performance when there is a large number of hits for a search.</details> | Liferay 7.2+<br />(Connector to Elasticsearch 7) |
+| Production Mode Enabled | <details><summary>`productionModeEnabled=B"false"`</summary>Enable production mode. In Liferay 7.3, <code>productionModeEnabled</code> replaces the deprecated setting <code>operationMode</code>. If this is checked, production mode is enabled and the Operation Mode configuration is ignored. Enabling production mode requires connecting to a remote standalone Elasticsearch cluster. If left disabled, the Operation Mode configuration is used.</details> | Liferay 7.3+ |
+| Index Name Prefix | <details><summary>`indexNamePrefix="liferay-"`</summary>Set a String value to use as the prefix for the search index name. The default value should not be changed under normal conditions. If you change it, you must also perform a *re-index all* operation for the portal and then manually delete the old index using the Elasticsearch administration console.</details> | Liferay 7.2+ |
+| 7.3.x&rarr;Number of Company and System Index Replicas<br />7.2.x&rarr;Index Number of Replicas | <details><summary>`indexNumberOfReplicas="0-all"`</summary>Set the number of replicas for each Liferay company and system index. If unset, no replicas are used. Changing this value requires a full re-index. The default value is defined in a file called "index-settings-defaults.json" shipped with the connector.</details> | Liferay 7.2+ |
+| 7.3.x&rarr;Number of Company and System Index Shards<br />7.2.x&rarr;Index Number of Shards | <details><summary>`indexNumberOfShards="1"`</summary>Set the number of shards to use when a Liferay company and system index is created. If unset, a single shard will be used. Changing this value requires a full re-index. The default value is defined in a file called "index-settings-defaults.json" shipped with the connector.</details> | Liferay 7.2+ |
+| Log Exceptions Only | <details><summary>`logExceptionsOnly=B"true"`</summary>A boolean setting that, when set to true, only logs exceptions from Elasticsearch, and does not re-throw them.</details> | Liferay 7.2+ |
+| Retry On Conflict | <details><summary>`retryOnConflict="5"`</summary></details> | Liferay 7.2- |
 | | <a href="#security-settings" id="security-settings">SECURITY SETTINGS</a> |
-| Authentication Enabled | `authenticationEnabled=B"false"` | Liferay 7.3+ |
-| Username | `username="elastic"` | Liferay 7.3+ |
-| Password | `password=""` | Liferay 7.3+ |
-| Http SSL Enabled | `httpSSLEnabled="false"` | Liferay 7.3+ |
-| Truststore Type | `truststoreType="pkcs12"` | Liferay 7.3+ |
-| Truststore Path | `truststorePath="/path/to/localhost.p12"` | Liferay 7.3+ |
-| Truststore Password | `truststorePassword=""` | Liferay 7.3+ |
+| Authentication Enabled | <details><summary>`authenticationEnabled=B"false"`</summary>Enable or disable authentication to Elasticsearch with a user name and password.</details> | Liferay 7.3+ |
+| Username | <details><summary>`username="elastic"`</summary>Set the user name for authenticating to Elasticsearch if Authentication Enabled is checked.</details> | Liferay 7.3+ |
+| Password | <details><summary>`password=""`</summary>Set the password for authenticating to Elasticsearch if Authentication Enabled is checked.</details> | Liferay 7.3+ |
+| Http SSL Enabled | <details><summary>`httpSSLEnabled="false"`</summary>Enable or disable TLS/SSL.</details> | Liferay 7.3+ |
+| Truststore Type | <details><summary>`truststoreType="pkcs12"`</summary>Set the truststore type if HTTP SSL Enabled is checked.</details> | Liferay 7.3+ |
+| Truststore Path | <details><summary>`truststorePath="/path/to/localhost.p12"`</summary>Set the path to the truststore file if HTTP SSL Enabled is checked.</details> | Liferay 7.3+ |
+| Truststore Password | <details><summary>`truststorePassword=""`</summary>Set the password to the truststore if HTTP SSL Enabled is checked.</details> | Liferay 7.3+ |
 | | <a href="#elasticsearch-connections-settings" id="elasticsearch-connections-settings">ELASTICSEARCH CONNECTIONS SETTINGS</a> |
-| Active | `active=B"false"` | Liferay 7.3+ |
-| Connection ID | `connectionId=""` | Liferay 7.3+ |
+| Active | <details><summary>`active=B"false"`</summary>Activate or deactivate the connection as needed. Do not deactivate a connection if it's selected in the Elasticsearch 7 configuration's Remote Cluster Connection ID setting.</details> | Liferay 7.3+ |
+| Connection ID | <details><summary>`connectionId=""`</summary>Set a unique ID for the connection. If active, this connection becomes available to select in the Elasticsearch 7 configuration's Remote Cluster Connection ID property.</details> | Liferay 7.3+ |
 | | <a href="#rest-client-settings" id="rest-client-settings">REST CLIENT SETTINGS</a> |
-| Network Host Addresses | `networkHostAddresses="[http://localhost:9200]"` | Liferay 7.3+ |
-| REST Client Logger Level | `RESTClientLoggerLevel="ERROR"` | Liferay 7.3+ |
+| Network Host Addresses | <details><summary>`networkHostAddresses="[http://localhost:9200]"`</summary>Set the remote HTTP hosts to connect to. This is required in Liferay 7.3 as it configures the REST client connection.</details> | Liferay 7.3+ |
+| REST Client Logger Level | <details><summary>`RESTClientLoggerLevel="ERROR"`</summary></details> | Liferay 7.3+ |
 | | <a href="#transport-client-settings" id="transport-client-settings">TRANSPORT CLIENT SETTINGS</a> |
-| Cluster Name | `clusterName="LiferayElasticsearchCluster"` | Liferay 7.2-<br />On 7.3+, applies to development mode |
-| Transport Addresses | `transportAddresses=["localhost:9300"]` | Liferay 7.2- |
-| Client Transport Sniff | `clientTransportSniff=B"true"` | Liferay 7.2- |
-| Client Transport Ignore Cluster Name | `clientTransportIgnoreClusterName=B"false"` | Liferay 7.2- |
-| Client Transport Ping Timeout | `clientTransportPingTimeout=""` | Liferay 7.2- |
-| Client Transport Nodes Sampler Interval | `clientTransportNodesSamplerInterval=""` | Liferay 7.2- |
+| Cluster Name | <details><summary>`clusterName="LiferayElasticsearchCluster"`</summary>The cluster name is only needed for the Transport Client in Liferay 7.2. Set a String value to declare the cluster to integrate with. In Liferay 7.3+, where the connection is managed through the REST client, this property is only used for naming the embedded cluster when in development mode.</details> | Liferay 7.2-<br />On 7.3+, applies to development mode |
+| Transport Addresses | <details><summary>`transportAddresses=["localhost:9300"]`</summary>Set the String values for the addresses of the remote Elasticsearch nodes to connect to. This value is required when Operation Mode is set to remote (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information). Specify as many or few nodes as you see fit.</details> | Liferay 7.2- |
+| Client Transport Sniff | <details><summary>`clientTransportSniff=B"true"`</summary>Set this boolean to true to enable cluster sniffing and dynamically discover available data nodes in the cluster (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).</details> | Liferay 7.2- |
+| Client Transport Ignore Cluster Name | <details><summary>`clientTransportIgnoreClusterName=B"false"`</summary>Set this boolean to true to ignore cluster name validation of connected nodes (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).</details> | Liferay 7.2- |
+| Client Transport Ping Timeout | <details><summary>`clientTransportPingTimeout=""`</summary>Set the time (in seconds) the client node waits for a ping response from a node. If unset, the default Elasticsearch `client.transport.ping_timeout` is used.</details> | Liferay 7.2- |
+| Client Transport Nodes Sampler Interval | <details><summary>`clientTransportNodesSamplerInterval=""`</summary>Set this String value to instruct the client node on how often to sample / ping the nodes listed and connected (see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/7.x/transport-client.html) for more information).</details> | Liferay 7.2- |
 | | <a href="#other-settings" id="other-settings">OTHER SETTINGS</a> |
-| Remote Cluster Connection ID | `remoteClusterConnectionId=` | Liferay 7.3+ when using [LES Cross-Cluster Replication](../../liferay-enterprise-search/cross-cluster-replication/cross-cluster-replication.md) |
+| Remote Cluster Connection ID | <details><summary>`remoteClusterConnectionId=`</summary>Choose the connection ID for a connection to the remote Elasticsearch cluster. The available connections are defined in the Elasticsearch Connections System Settings entry. If this value is not set then the connection configurations in the Elasticsearch 7 entry are used for the remote cluster connection.</details> | Liferay 7.3+ when using [LES Cross-Cluster Replication](../../liferay-enterprise-search/cross-cluster-replication/cross-cluster-replication.md) |
 | | <a href="#development-mode-settings" id="development-mode-settings">DEVELOPMENT MODE SETTINGS</a> | 
-| Bootstrap Mlock All | `bootstrapMlockAll="false"` | Liferay 7.2+ |
-| Http CORS Allow Origin | `httpCORSAllowOrigin="/https?:\\/\\/localhost(:[0-9]+)?/"` | Liferay 7.2+ |
-| Http CORS Configurations | `httpCORSConfigurations=` | Liferay 7.2+ |
-| Http CORS Enabled | `httpCORSEnabled=B"true"` | Liferay 7.2+ |
-| Network Host | `networkHost=""` | Liferay 7.2+  |
-| Network Bind Host | `networkBindHost=""` | Liferay 7.2+ |
-| Network Publish Host | `networkPublishHost=""` | Liferay 7.2+ |
-| Node Name | `nodeName=` | Liferay 7.3+ |
-| Sidecar Debug | `sidecarDebug=B"false"` | Liferay 7.3+ |
-| Sidecar Debug Settings | `sidecarDebugSettings="-agentlib:jdwp=transport=dt_socket,address=8001,server=y,suspend=y,quiet=y"` | Liferay 7.3+ |
-| Sidecar Heartbeat Interval | `sidecarHeartbeatInterval="10000"` | Liferay 7.3+ |
-| Sidecar Home | `sidecarHome="elasticsearch7"` | Liferay 7.3+ |
-| Sidecar HTTP Port | `sidecarHttpPort="9200"` | Liferay 7.3+ |
-| Sidecar JVM Options | `sidecarJVMOptions="-Xms1g\|-Xmx1g\|-XX:+AlwaysPreTouch"` | Liferay 7.3+ |
-| Sidecar Shutdown Timeout | `sidecarShutdownTimeout="10000"` | Liferay 7.3+ |
-| Transport Tcp Port | `transportTcpPort=""` | Liferay 7.2+ |
-| Zen Discovery Unicast Hosts Port | `discoveryZenPingUnicastHostsPort="9300-9400"` | Liferay 7.2+ |
+| Bootstrap Mlock All | <details><summary>`bootstrapMlockAll="false"`</summary>A boolean setting that, when set to `true`, tries to lock the process address space into RAM, preventing any Elasticsearch memory from being swapped out (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/setup-configuration-memory.html#bootstrap-memory_lock)) for more information).</details> | Liferay 7.2+ |
+| Http CORS Allow Origin | <details><summary>`httpCORSAllowOrigin="/https?:\\/\\/localhost(:[0-9]+)?/"`</summary>Set the String origins to allow when HTTP CORS is enabled (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).</details> | Liferay 7.2+ |
+| Http CORS Configurations | <details><summary>`httpCORSConfigurations=`</summary>Set the String values for custom settings for HTTP CORS, in YML format (`elasticsearch.yml`) (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).</details> | Liferay 7.2+ |
+| Http CORS Enabled | <details><summary>`httpCORSEnabled=B"true"`</summary>Set this boolean to false to disable cross-origin resource sharing. When set to `false`, a browser on another origin cannot make requests to Elasticsearch. Web front end tools like Elasticsearch Head may be unable to connect (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-http.html#_settings) for more information).</details> | Liferay 7.2+ |
+| Network Host | <details><summary>`networkHost=""`</summary>Set this String value to instruct the node to bind to this hostname or IP address and publish (advertise) this host to other nodes in the cluster. This is a shortcut which sets the bind host and the publish host at the same time (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#common-network-settings) for more information).</details> | Liferay 7.2+  |
+| Network Bind Host | <details><summary>`networkBindHost=""`</summary>Set the String value of the network interface(s) a node should bind to in order to listen for incoming requests (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#advanced-network-settings) for more information).</details> | Liferay 7.2+ |
+| Network Publish Host | <details><summary>`networkPublishHost=""`</summary>Set the String value of a single interface that the node advertises to other nodes in the cluster, so that those nodes can connect to it (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-network.html#advanced-network-settings) for more information).</details> | Liferay 7.2+ |
+| Node Name | <details><summary>`nodeName=`</summary>Name the embedded Elasticsearch server's node. A remote Elasticsearch server's node name is configured in its `elasticsearch.yml`.</details> | Liferay 7.3+ |
+| Sidecar Debug | <details><summary>`sidecarDebug=B"false"`</summary>Set this to true to enable debug mode for the sidecar process.</details> | Liferay 7.3+ |
+| Sidecar Debug Settings | <details><summary>`sidecarDebugSettings="-agentlib:jdwp=transport=dt_socket,address=8001,server=y,suspend=y,quiet=y"`</summary>Set the JVM options used to debug the sidecar process.</details> | Liferay 7.3+ |
+| Sidecar Heartbeat Interval | <details><summary>`sidecarHeartbeatInterval="10000"`</summary>Set the heartbeat interval in milliseconds used to detect the health of the sidecar process.</details> | Liferay 7.3+ |
+| Sidecar Home | <details><summary>`sidecarHome="elasticsearch7"`</summary>Set the path of the sidecar base folder used to start the sidecar process.</details> | Liferay 7.3+ |
+| Sidecar HTTP Port | <details><summary>`sidecarHttpPort="9200"`</summary>This configuration only applies to Liferay 7.3 with the sidecar Elasticsearch. Set the HTTP port range of the sidecar Elasticsearch node. Set to AUTO to automatically find a port in the 9201-9300 range. If unset, the value of Embedded HTTP port (`9201` by default) is used.</details> | Liferay 7.3+ |
+| Sidecar JVM Options | <details><summary>`sidecarJVMOptions="-Xms1g\|-Xmx1g\|-XX:+AlwaysPreTouch"`</summary>Set the JVM options used by the sidecar process.</details> | Liferay 7.3+ |
+| Sidecar Shutdown Timeout | <details><summary>`sidecarShutdownTimeout="10000"`</summary>Set the time in milliseconds to wait before the sidecar process is forcibly shut down.</details> | Liferay 7.3+ |
+| Transport Tcp Port | <details><summary>`transportTcpPort=""`</summary>Set the String value for the port to bind for communication between nodes.  Accepts a single value or a range (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-transport.html#_tcp_transport) for more information).</details> | Liferay 7.2+ |
+| Zen Discovery Unicast Hosts Port | <details><summary>`discoveryZenPingUnicastHostsPort="9300-9400"`</summary>Set a String value for the range of ports to use when building the value for `discovery.zen.ping.unicast.hosts`. Multiple Elasticsearch nodes on a range of ports can act as gossip routers at the same computer (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/modules-discovery-hosts-providers.html) for more information).</details> | Liferay 7.2+ |
 | | <a href="#advanced-settings" id="advanced-settings">ADVANCED SETTINGS</a> |
-| Additional Configurations | `additionalConfigurations=""` | Liferay 7.2+ |
-| Additional Index Configurations | `additionalIndexConfigurations=""` | Liferay 7.2+ |
-| Additional Type Mappings | `additionalTypeMappings=""` | Liferay 7.2+ |
-| Override Type Mappings | `overrideTypeMappings=""` | Liferay 7.2+ |
-| Proxy Host | `proxyHost=""` | Liferay DXP 7.3 FP1+/SP1+ and Liferay Portal CE GA7+ |
-| Proxy Port | `proxyPort="0"` | Liferay DXP 7.3 FP1+/SP1+ and Liferay Portal CE GA7+ |
-| Proxy Username | `proxyUserName=""` | Liferay DXP 7.3 FP1+/SP1+ and Liferay Portal CE GA7+ |
-| Proxy Password | `proxyPassword=""` | Liferay DXP 7.3 FP1+/SP1+ and Liferay Portal CE GA7+ |
+| Additional Configurations | <details><summary>`additionalConfigurations=""`</summary>Set the String values for custom settings for embedded Elasticsearch, in YML format. See: Adding Settings to the Liferay Elasticsearch Connector.</details> | Liferay 7.2+ |
+| Additional Index Configurations | <details><summary>`additionalIndexConfigurations=""`</summary>Set the String values for custom settings for the Liferay index, in JSON or YML format (refer to the Elasticsearch Create Index API for more information).  See: Adding Settings to the Liferay Elasticsearch Connector.</details> | Liferay 7.2+ |
+| Additional Type Mappings | <details><summary>`additionalTypeMappings=""`</summary>Set the String values for custom mappings for the `LiferayDocumentType`, in JSON format (refer to the Elasticsearch Put Mapping API for more information) See: Adding Settings to the Liferay Elasticsearch Connector.</details> | Liferay 7.2+ |
+| Override Type Mappings | <details><summary>`overrideTypeMappings=""`</summary>Settings here override Liferay's default type mappings. This is an advanced feature that should be used only if strictly necessary. If you set this value, the default mappings used to define the Liferay Document Type in Liferay source code (for example, `liferay-type-mappings.json`) are ignored entirely, so include the whole mappings definition in this property, not just the segment you're modifying.</details> | Liferay 7.2+ |
+| Proxy Host | <details><summary>`proxyHost=""`</summary>Set the proxy host for the client connection.</details> | Liferay DXP 7.3 FP1+/SP1+ and Liferay Portal CE GA7+ |
+| Proxy Port | <details><summary>`proxyPort="0"`</summary>Set the proxy port for the client connection.</details> | Liferay DXP 7.3 FP1+/SP1+ and Liferay Portal CE GA7+ |
+| Proxy Username | <details><summary>`proxyUserName=""`</summary>Set the proxy user name for a proxy connection.</details> | Liferay DXP 7.3 FP1+/SP1+ and Liferay Portal CE GA7+ |
+| Proxy Password | <details><summary>`proxyPassword=""`</summary>Set the password for connecting to the proxy.</details> | Liferay DXP 7.3 FP1+/SP1+ and Liferay Portal CE GA7+ |
 | | <a href="#deprecated-settings" id="deprecated-settings">DEPRECATED</a> |
-| Operation Mode | `operationMode="EMBEDDED"` | Deprecated as of Liferay 7.3, replaced with _Production Mode Enabled_  |
-| Embedded HTTP Port | `embeddedHttpPort="9201"` | Deprecated as of Liferay 7.3.x |
-| Http Enabled | `httpEnabled=B"true"` | Deprecated as of Liferay 7.1.x<br />Deprecated Elasticsearch 6.3.x |
+| Operation Mode | <details><summary>`operationMode="EMBEDDED"`</summary>There are two operation modes you can choose from: EMBEDDED or REMOTE. Set to REMOTE to connect to a remote standalone Elasticsearch cluster. Set to EMBEDDED to start Liferay with an internal Elasticsearch instance. EMBEDDED operation mode is unsupported for production environments and can be considered a "development mode" feature.</details> | Deprecated as of Liferay 7.3, replaced with _Production Mode Enabled_  |
+| Embedded HTTP Port | <details><summary>`embeddedHttpPort="9201"`</summary></details> | Deprecated as of Liferay 7.3.x |
+| Http Enabled | <details><summary>`httpEnabled=B"true"`</summary></details> | Deprecated as of Liferay 7.1.x<br />Deprecated Elasticsearch 6.3.x |
 
+
+<!-- 
 ## Property Descriptions
 
 The configuration settings are categorized by where they appear: those unique to the Elasticsearch 7 entry, those unique to the Elasticsearch connections entry, and those common to both. The Elasticsearch 7 and Elasticsearch Connections entries are found under System Settings &rarr; Search.
@@ -257,3 +258,4 @@ Set the password for connecting to the proxy.
 - [Connecting to Elasticsearch](connecting-to-elasticsearch.md)
 - [Liferay DXP Elasticsearch Connectors: Technical Data Sheet (KB Reference)](https://help.liferay.com/hc/en-us/articles/360046478452)
 - [Understanding Liferay DXP's compatibility with Elasticsearch (KB Reference)](https://help.liferay.com/hc/en-us/articles/360051492032)
+    -->


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-9431
cc @lipusz, @jrhoun
Rich, JR, we made use of the HTML `details` tag, so that our enormous table can take advantage of collapsible property descriptions--it's never the case that you need to see them all at once--you're probably scanning this material to find just the property you need.