### PR TITLE
LRDOCS-10249 Location of frontend-token-definitions.json

### DIFF
--- a/docs/dxp/latest/en/building-applications/data-frameworks/upgrade-processes.md
+++ b/docs/dxp/latest/en/building-applications/data-frameworks/upgrade-processes.md
@@ -1,5 +1,11 @@
 # Upgrade Processes
 
+```{toctree}
+:maxdepth: 3
+
+upgrade-processes/multithreading-process.md
+```
+
 ```{raw} html
 :file: ../../landingpage_template.html
 ```

--- a/docs/dxp/latest/en/building-applications/data-frameworks/upgrade-processes/landing.html
+++ b/docs/dxp/latest/en/building-applications/data-frameworks/upgrade-processes/landing.html
@@ -4,6 +4,10 @@
 		data: {
 			cards: [
 				{
+					sectionName: 'Multithreading Process',
+					sectionURL: 'upgrade-processes/multithreading-process.html',
+				},
+				{
 					sectionName: 'Introduction to Upgrade Processes (Help Center)',
 					sectionURL: 'https://help.liferay.com/hc/en-us/articles/360031165731-Introduction-to-Upgrade-Processes',
 				},
@@ -18,10 +22,6 @@
 				{
 					sectionName: 'Upgrading Data Schemas in Development (Help Center)',
 					sectionURL: 'https://help.liferay.com/hc/en-us/articles/360031165791-Upgrading-Data-Schemas-in-Development',
-				},
-				{
-					sectionName: 'Multithreading Process',
-					sectionURL: 'upgrade-processes/multithreading-process.html',
 				},
 			]
 		}

--- a/docs/dxp/latest/en/site-building/site-appearance/style-books/developer-guide/style-book-token-definitions.md
+++ b/docs/dxp/latest/en/site-building/site-appearance/style-books/developer-guide/style-book-token-definitions.md
@@ -8,7 +8,7 @@ When you assign a theme to your Site's Public Pages, the token definition includ
 
 ## Defining Tokens for Your Style Book
 
-Since the token definition is tied to your theme, token definitions must correspond to a CSS variable contained within your theme module. Specify the token definitions themselves in a `.json` file within your theme module's folder, named `frontend-token-definition.json`. 
+Since the token definition is tied to your theme, token definitions must correspond to a CSS variable contained within your theme module. Specify the token definitions themselves in a `.json` file within your theme module's `src/WEB-INF/` folder, named `frontend-token-definition.json`. 
 
 ### Token Categories
 
@@ -16,7 +16,7 @@ Tokens defining the options for configuring your Style Book are grouped into cat
 
 ![Each of the options in the drop-down menu corresponds to one category of Style Book tokens.](./style-book-token-definitions/images/01.png)
 
-Define each of these categories within a `frontendTokenCategories` field within your `frontend-token-definition.json` file:
+Define each of these categories within a `frontendTokenCategories` field within your theme's `frontend-token-definition.json` file in `src/WEB-INF/`:
 
 ```json
 {
@@ -126,7 +126,7 @@ Here is an example list of tokens within a token set:
 
 ## Matching CSS Variables to Style Book Tokens
 
-The `frontend-token-definition.json` file containing your token definition must be in the `src/WEB-INF` folder of your theme module folder. Every token defined in your token definition must represent a style (color, spacing, font, etc.) in the CSS of your theme.
+The `frontend-token-definition.json` file containing your token definition must be in the `src/WEB-INF/` folder of your theme module folder. Every token defined in your token definition must represent a style (color, spacing, font, etc.) in the CSS of your theme.
 
 All styles that your tokens represent must be coded as CSS variables. For example, take this definition of a token (giving an option to configure a font):
 


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-10249

Originally proposed by: https://github.com/liferay/liferay-learn/pull/208/files

The location of `frontend-token-definitions.json` was not mentioned until late in the article, which may be confusing for readers. This mentions it earlier on and more consistently to avoid this confusion. (Stating it every time might be quite repetitive but I figure it is still a positive trade-off)